### PR TITLE
fix #41 Align ShapeGeoJsonProperties with ImportGeoJsonProperties

### DIFF
--- a/src/core/features/feature-data.ts
+++ b/src/core/features/feature-data.ts
@@ -185,7 +185,7 @@ export class FeatureData {
     });
   }
 
-  updateGeoJsonProperties(properties: ShapeGeoJsonProperties) {
+  updateGeoJsonProperties(properties: Partial<ShapeGeoJsonProperties>) {
     if (!this.isFeatureAvailable()) {
       throw new Error(`Feature not found: "${this.id}"`);
     }

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -14,6 +14,7 @@ export type ShapeGeoJsonProperties = {
   [FEATURE_ID_PROPERTY]?: FeatureId,
   center?: LngLat,
   text?: string,
+  [key: string]: unknown,
 };
 export type FeatureDataParameters = {
   gm: Geoman,


### PR DESCRIPTION
Hi @mscno,

This PR suggests updating the `ShapeGeoJsonProperties` type to allow additional custom properties by extending it with an index signature.
