### PR TITLE
fix #39 order of geoman layers

### DIFF
--- a/src/core/features/index.ts
+++ b/src/core/features/index.ts
@@ -37,9 +37,9 @@ import log from 'loglevel';
 
 
 export const SOURCES = {
+  standby: `${gmPrefix}_standby`,
   main: `${gmPrefix}_main`,
   temporary: `${gmPrefix}_temporary`,
-  standby: `${gmPrefix}_standby`,
 } as const;
 
 export const FEATURE_ID_PROPERTY = '_gmid' as const;
@@ -554,23 +554,23 @@ export class Features {
   createLayers(): Array<BaseLayer> {
     const layers: Array<BaseLayer> = [];
 
-    typedKeys(this.gm.options.layerStyles).forEach((shapeName) => {
-      typedKeys(this.gm.options.layerStyles[shapeName]).forEach((sourceName) => {
-        const styles = this.gm.options.layerStyles[shapeName][sourceName];
-        styles.forEach((partialStyle) => {
-          const layer = this.createGenericLayer({
-            layerId: `${sourceName}-${shapeName}-${partialStyle.type}-layer`,
-            partialStyle,
-            shape: shapeName,
-            sourceName,
+    typedValues(SOURCES).forEach((sourceName) => {
+      typedKeys(this.gm.options.layerStyles).forEach((shapeName) => {
+          const styles = this.gm.options.layerStyles[shapeName][sourceName];
+          styles.forEach((partialStyle) => {
+            const layer = this.createGenericLayer({
+              layerId: `${sourceName}-${shapeName}-${partialStyle.type}-layer`,
+              partialStyle,
+              shape: shapeName,
+              sourceName,
+            });
+  
+            if (layer) {
+              layers.push(layer);
+            }
           });
-
-          if (layer) {
-            layers.push(layer);
-          }
-        });
       });
-    });
+    })
 
     return layers;
   }

--- a/src/core/options/layers/style.ts
+++ b/src/core/options/layers/style.ts
@@ -11,12 +11,7 @@ import { sourceStyles } from '@/core/options/layers/variables.ts';
 import type { FeatureShape, LayerStyle } from '@/main.ts';
 
 const styles: { [key in FeatureShape]: LayerStyle } = {
-  line: {
-    [SOURCES.main]: getLineStyles(sourceStyles[SOURCES.main]),
-    [SOURCES.temporary]: getLineStyles(sourceStyles[SOURCES.temporary]),
-    [SOURCES.standby]: getLineStyles(sourceStyles[SOURCES.standby]),
-  },
-  circle: {
+  polygon: {
     [SOURCES.main]: getPolygonStyles(sourceStyles[SOURCES.main]),
     [SOURCES.temporary]: getPolygonStyles(sourceStyles[SOURCES.temporary]),
     [SOURCES.standby]: getPolygonStyles(sourceStyles[SOURCES.standby]),
@@ -26,31 +21,25 @@ const styles: { [key in FeatureShape]: LayerStyle } = {
     [SOURCES.temporary]: getPolygonStyles(sourceStyles[SOURCES.temporary]),
     [SOURCES.standby]: getPolygonStyles(sourceStyles[SOURCES.standby]),
   },
-  polygon: {
+  circle: {
     [SOURCES.main]: getPolygonStyles(sourceStyles[SOURCES.main]),
     [SOURCES.temporary]: getPolygonStyles(sourceStyles[SOURCES.temporary]),
     [SOURCES.standby]: getPolygonStyles(sourceStyles[SOURCES.standby]),
-  },
-  marker: {
-    [SOURCES.temporary]: getMarkerStyles(),
-    [SOURCES.main]: getMarkerStyles(),
-    [SOURCES.standby]: getMarkerStyles(),
   },
   circle_marker: {
     [SOURCES.main]: getCircleMarkerStyles(sourceStyles[SOURCES.main]),
     [SOURCES.temporary]: getCircleMarkerStyles(sourceStyles[SOURCES.temporary]),
     [SOURCES.standby]: getCircleMarkerStyles(sourceStyles[SOURCES.standby]),
   },
+  line: {
+    [SOURCES.main]: getLineStyles(sourceStyles[SOURCES.main]),
+    [SOURCES.temporary]: getLineStyles(sourceStyles[SOURCES.temporary]),
+    [SOURCES.standby]: getLineStyles(sourceStyles[SOURCES.standby]),
+  },
   text_marker: {
     [SOURCES.main]: getTextMarkerStyles(),
     [SOURCES.temporary]: getTextMarkerStyles(),
     [SOURCES.standby]: getTextMarkerStyles(),
-  },
-  dom_marker: {
-    // not a geojson source, layers aren't required
-    [SOURCES.main]: [],
-    [SOURCES.temporary]: [],
-    [SOURCES.standby]: [],
   },
   center_marker: {
     [SOURCES.main]: getControlMarkerStyles(sourceStyles[SOURCES.main]),
@@ -62,10 +51,21 @@ const styles: { [key in FeatureShape]: LayerStyle } = {
     [SOURCES.temporary]: getControlMarkerStyles(sourceStyles[SOURCES.temporary]),
     [SOURCES.standby]: getControlMarkerStyles(sourceStyles[SOURCES.standby]),
   },
+  marker: {
+    [SOURCES.temporary]: getMarkerStyles(),
+    [SOURCES.main]: getMarkerStyles(),
+    [SOURCES.standby]: getMarkerStyles(),
+  },
   edge_marker: {
     [SOURCES.main]: getSecondaryControlMarkerStyles(sourceStyles[SOURCES.main]),
     [SOURCES.temporary]: getSecondaryControlMarkerStyles(sourceStyles[SOURCES.temporary]),
     [SOURCES.standby]: getSecondaryControlMarkerStyles(sourceStyles[SOURCES.standby]),
+  },
+  dom_marker: {
+    // not a geojson source, layers aren't required
+    [SOURCES.main]: [],
+    [SOURCES.temporary]: [],
+    [SOURCES.standby]: [],
   },
   snap_guide: {
     // todo: check which sources can't display snap guides (and other shapes) and remove layers


### PR DESCRIPTION
This PR proposes a more predictable ordering of Geoman layers, aiming to resolve z-index issues such as lines being rendered behind polygons.

This suggestion takes advantage of the fact that `Object.keys` preserves insertion order, allowing fine-grained control over rendering.

Happy to adjust or discard if there's a better way — this is just a proposal.

Thanks for your library!