### PR TITLE
fix destroy method

### DIFF
--- a/src/core/map/maplibre/index.ts
+++ b/src/core/map/maplibre/index.ts
@@ -70,8 +70,10 @@ export class MaplibreAdapter
   }
 
   async loadImage({ id, image }: { id: string, image: string }) {
-    const loadedImage = await this.mapInstance.loadImage(image);
-    this.mapInstance.addImage(id, loadedImage.data);
+    if (!this.mapInstance.hasImage(id)) {
+      const loadedImage = await this.mapInstance.loadImage(image);
+      this.mapInstance.addImage(id, loadedImage.data);
+    }
   }
 
   getBounds(): [LngLat, LngLat] {

--- a/src/core/map/maplibre/layer.ts
+++ b/src/core/map/maplibre/layer.ts
@@ -42,8 +42,12 @@ export class MaplibreLayer extends BaseLayer<MaplibreAnyLayer> {
   }
 
   createLayer(options: ml.AddLayerObject): MaplibreAnyLayer {
-    this.mapInstance.addLayer(options);
-    return this.mapInstance.getLayer(options.id) as MaplibreAnyLayer || null;
+    let layer = this.mapInstance.getLayer(options.id) as MaplibreAnyLayer | undefined;
+    if (!layer) {
+      this.mapInstance.addLayer(options);
+      layer = this.mapInstance.getLayer(options.id) as MaplibreAnyLayer;
+    }
+    return layer ?? null
   }
 
   remove(): void {

--- a/src/core/map/maplibre/source.ts
+++ b/src/core/map/maplibre/source.ts
@@ -41,12 +41,16 @@ export class MaplibreSource extends BaseSource<ml.GeoJSONSource> {
   createSource(
     { geoJson, sourceId }: { sourceId: string, geoJson: GeoJSON },
   ): ml.GeoJSONSource {
-    this.mapInstance.addSource(sourceId, {
-      type: 'geojson',
-      data: geoJson,
-      promoteId: FEATURE_ID_PROPERTY,
-    });
-    return this.mapInstance.getSource(sourceId) as ml.GeoJSONSource || null;
+    let source = this.mapInstance.getSource(sourceId) as ml.GeoJSONSource | undefined;
+    if (!source) {
+      this.mapInstance.addSource(sourceId, {
+        type: 'geojson',
+        data: geoJson,
+        promoteId: FEATURE_ID_PROPERTY,
+      });
+      source = this.mapInstance.getSource(sourceId) as ml.GeoJSONSource
+    }
+    return source ?? null;
   }
 
   getGeoJson() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,9 +142,17 @@ export class Geoman {
     await this.addControls();
   }
 
-  destroy() {
+  destroy(removeLayers = true) {
     this.removeControls();
     this.events.bus.detachAllEvents();
+
+    if (removeLayers) {
+      for (const source of Object.values(this.features.sources)) {
+        if (source) {
+          source.remove({ removeLayers });
+        }
+      }
+    }
 
     if ('gm' in this.mapAdapter.mapInstance) {
       delete this.mapAdapter.mapInstance.gm;


### PR DESCRIPTION
Hi,

When calling the destroy method, sources and layers were not being removed. Additionally, when reinstantiating Geoman, there were no checks to prevent re-adding the default-marker image, nor any checks for existing sources or layers.

This PR improves the destroy method by allowing proper layer removal and adds verification when instantiating Geoman to avoid duplicate sources, layers, or images.


https://github.com/user-attachments/assets/5d215073-8440-4fe7-8d3f-2eaaa56cc8c7

