### PR TITLE
fix deleting internal marker

### DIFF
--- a/src/modes/edit/delete.ts
+++ b/src/modes/edit/delete.ts
@@ -1,8 +1,9 @@
 import { SOURCES } from '@/core/features/index.ts';
-import type { AnyEvent, EditModeName, MapHandlerReturnData } from '@/main.ts';
+import type { AnyEvent, EditModeName, FeatureShape, MapHandlerReturnData } from '@/main.ts';
 import { BaseEdit } from '@/modes/edit/base.ts';
 import { isMapPointerEvent } from '@/utils/guards/map.ts';
 
+const internalShapes: FeatureShape[] = ["vertex_marker", "center_marker", "edge_marker", "snap_guide"]
 
 export class EditDelete extends BaseEdit {
   mode: EditModeName = 'delete';
@@ -26,7 +27,7 @@ export class EditDelete extends BaseEdit {
     }
 
     const feature = this.gm.features.getFeatureByMouseEvent({ event, sourceNames: [SOURCES.main] });
-    if (feature) {
+    if (feature && !internalShapes.includes(feature.shape)) {
       this.gm.features.delete(feature);
       this.fireFeatureRemovedEvent(feature);
     }


### PR DESCRIPTION
Hi,

This is a small fix: when `ShapeMarkersHelper` is enabled together with `EditDelete`, it’s currently possible to delete internal markers, which I believe is unintended.

https://github.com/user-attachments/assets/75ffe487-e04d-489b-93df-fd071a6de686





I also have a question about the use of a deep `isEqual` comparator in `queryFeaturesByScreenCoordinates` 

```diff
// src/core/map/maplibre/index.ts
import { isEqual, uniqWith } from 'lodash-es';


export class MaplibreAdapter {
  queryFeaturesByScreenCoordinates({ queryCoordinates = undefined, sourceNames }: {
    queryCoordinates?: ScreenPoint | [ScreenPoint, ScreenPoint],
    sourceNames: Array<FeatureSourceName>,
  }): Array<FeatureData> {
+   const features = uniqWith(this.mapInstance
      .queryRenderedFeatures(queryCoordinates)
      .map((feature) => ({
        featureId: feature.properties[FEATURE_ID_PROPERTY] as FeatureId | undefined,
        featureSourceName: feature.source as FeatureSourceName,
+     })), isEqual);

    return features.map(({ featureId, featureSourceName }) => {
      if (featureId === undefined || !sourceNames.includes(featureSourceName)) {
        return null;
      }

      return this.gm.features.get(featureSourceName, featureId) || null;
    }).filter((featureData): featureData is FeatureData => !!featureData);
  }
}
```

Wouldn’t it be sufficient to use a comparator that only checks strict equality on featureId instead of doing a deep comparison?

Thanks a lot, and have a great day!