### PR TITLE
Proof of concept to reduce queue size in MapLibreSource

### DIFF
--- a/perf-poc.html
+++ b/perf-poc.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="icon" href="data:," />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Geoman plugin</title>
+  </head>
+  <body>
+    <div id="dev-map"></div>
+
+    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/src/dev/perf-poc.ts"></script>
+  </body>
+</html>

--- a/src/core/map/maplibre/helper.ts
+++ b/src/core/map/maplibre/helper.ts
@@ -1,0 +1,39 @@
+import type { GeoJsonDiffStorage } from "@/types";
+import type { Feature } from "geojson"
+
+export function mergeGeoJsonDiff(
+  pendingDiffOrNull: GeoJsonDiffStorage | null,
+  nextDiffOrNull: GeoJsonDiffStorage | null
+): GeoJsonDiffStorage {
+  const pending: GeoJsonDiffStorage = pendingDiffOrNull ?? {add: [], update: [], remove: []}
+  const next: GeoJsonDiffStorage = nextDiffOrNull ?? {add: [], update: [], remove: []}
+
+  const nextRemoveIds = new Set(next.remove);
+
+  const pendingAdd = pending.add.filter((f) => !nextRemoveIds.has(f.id!))
+  const pendingUpdate = pending.update.filter((f) => !nextRemoveIds.has(f.id!))
+
+  const nextUpdate: Array<Feature> = [];
+
+  next.update.forEach((updatedFeature) => {
+    const pendingAddIdx = pendingAdd.findIndex(f => f.id === updatedFeature.id)
+    const pendingUpdateIdx = pendingUpdate.findIndex(f => f.id === updatedFeature.id)
+
+    if (pendingAddIdx === -1 && pendingUpdateIdx === -1) {
+      nextUpdate.push(updatedFeature)
+      return
+    }
+    if (pendingAddIdx !== -1) {
+      pendingAdd[pendingAddIdx] = updatedFeature;
+    }
+    if (pendingUpdateIdx !== -1) {
+      pendingUpdate[pendingUpdateIdx] = updatedFeature;
+    }
+  });
+
+  return {
+    add: [...pendingAdd, ...next.add],
+    update: [...pendingUpdate, ...nextUpdate],
+    remove: [...pending.remove, ...next.remove]
+  }
+}

--- a/src/dev/perf-poc.ts
+++ b/src/dev/perf-poc.ts
@@ -1,0 +1,74 @@
+import log from 'loglevel';
+import 'maplibre-gl/dist/maplibre-gl.css';
+
+import '@/dev/styles/style.css';
+import '@/styles/map/maplibre.css';
+
+import mapLibreStyle from '@/dev/maplibre-style.ts';
+
+import ml from 'maplibre-gl';
+import { FEATURE_ID_PROPERTY, Geoman } from '@/main.ts';
+import type { GeoJsonImportFeature, GeoJsonImportFeatureCollection, LngLat } from '@/main.ts';
+
+log.setLevel(log.levels.TRACE);
+
+const existingMapInstance = window.customData?.map as ml.Map | undefined;
+
+
+const map = existingMapInstance || new ml.Map({
+  container: 'dev-map',
+  style: mapLibreStyle,
+  center: [0, 51],
+  zoom: 5,
+  fadeDuration: 50,
+});
+
+const geoman = new Geoman(map, {
+  settings: {
+    throttlingDelay:10
+  },
+});
+
+const loadStressTestFeatureCollection = (step: number, size: number) => {
+
+  const geoJson: GeoJsonImportFeatureCollection = {
+    type: 'FeatureCollection',
+    features: [],
+  };
+
+  const createPolygonFeature = (coords: Array<LngLat>): GeoJsonImportFeature => {
+    const featureId = `${coords[0][0]}-${coords[0][1]}`;
+    return {
+      id: featureId,
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [coords],
+      },
+      properties: {
+        [FEATURE_ID_PROPERTY]: featureId,
+        shape: 'rectangle',
+      },
+    };
+  };
+
+  for (let lng = -10; lng < 10; lng += step) {
+    for (let lat = 56; lat > 46; lat -= step) {
+      const feature = createPolygonFeature([
+        [lng, lat],
+        [lng + size, lat],
+        [lng + size, lat - size],
+        [lng, lat - size],
+        [lng, lat],
+      ]);
+
+      geoJson.features.push(feature);
+    }
+  }
+
+  return geoJson;
+};
+
+map.on("gm:loaded", () => {
+  geoman.features.importGeoJson(loadStressTestFeatureCollection(0.2, 0.18));
+});


### PR DESCRIPTION
This is a draft PR to share and discuss a possible workaround to improve performance when editing vertices of geometries. It's the code describe in #48.

This approach aims to:
- Reduce unnecessary intermediate updates.
- Avoid flooding the MapLibre internal queue.
- Keep the last meaningful diff instead of every transient vertex move.

link: http://localhost:3100/perf-poc.html

⚠️ Notes

This code is not meant to be merged as-is, but could serve as inspiration for a proper, cleaner solution.

The initial delay when editing still exists, but performance is noticeably better once edits start.

🧩 Possible combined approach
This modification, combined with the idea described here:

> Would it be possible to have a two-step editing process?
>
> first, when the user clicks a geometry. its source toggles from main to temporary (or temporary back to main). Then, the addMarkers method is called only for features from temporary source.
>
> with this approach, the lag is significantly reduced:
>
> The example doesn’t exactly reproduce the desired behavior, but it shows that by enabling shape markers only on a single geometry, the performance issues are significantly reduced.

Happy to get your feedback