### PR TITLE
Align PartialLayerStyle type with MapLibre Style spec

### DIFF
--- a/src/core/map/maplibre/styleSpec.ts
+++ b/src/core/map/maplibre/styleSpec.ts
@@ -1,0 +1,26 @@
+import type {
+  CircleLayerSpecification,
+  FillLayerSpecification,
+  LineLayerSpecification,
+  SymbolLayerSpecification,
+} from "maplibre-gl";
+
+export type PartialCircleLayer = Pick<
+  CircleLayerSpecification,
+  "type" | "paint" | "layout"
+>;
+
+export type PartialLineLayer = Pick<
+  LineLayerSpecification,
+  "type" | "paint" | "layout"
+>;
+
+export type PartialFillLayer = Pick<
+  FillLayerSpecification,
+  "type" | "paint" | "layout"
+>;
+
+export type PartialSymbolLayer = Pick<
+  SymbolLayerSpecification,
+  "type" | "paint" | "layout"
+>;

--- a/src/types/map/layers.ts
+++ b/src/types/map/layers.ts
@@ -1,5 +1,17 @@
-import type { SourcesStorage } from '@/types/features.ts';
+import type { SourcesStorage } from "@/types/features.ts";
+import type {
+  PartialCircleLayer,
+  PartialLineLayer,
+  PartialFillLayer,
+  PartialSymbolLayer,
+} from "@mapLib/styleSpec.ts";
 
+export type {
+  PartialCircleLayer,
+  PartialLineLayer,
+  PartialFillLayer,
+  PartialSymbolLayer,
+};
 
 export type StyleVariables = {
   lineColor: string,
@@ -9,62 +21,6 @@ export type StyleVariables = {
   fillOpacity: number,
   circleMarkerRadius: number,
 };
-
-export interface PartialCircleLayer {
-  type: 'circle',
-  paint?: {
-    'circle-radius'?: number,
-    'circle-color'?: string,
-    'circle-opacity'?: number,
-    'circle-stroke-width'?: number,
-    'circle-stroke-color'?: string,
-    'circle-stroke-opacity'?: number,
-  },
-}
-
-export interface PartialLineLayer {
-  type: 'line',
-  paint?: {
-    'line-color'?: string,
-    'line-width'?: number,
-    'line-opacity'?: number,
-    'line-dasharray'?: number[],
-  },
-  layout?: {
-    'line-cap'?: 'butt' | 'round' | 'square',
-    'line-join'?: 'bevel' | 'round' | 'miter',
-  },
-}
-
-export interface PartialFillLayer {
-  type: 'fill',
-  paint?: {
-    'fill-color'?: string,
-    'fill-opacity'?: number,
-    'fill-outline-color'?: string,
-    'fill-antialias'?: boolean,
-  },
-}
-
-export interface PartialSymbolLayer {
-  type: 'symbol',
-  layout?: {
-    'icon-image'?: string,
-    'icon-size'?: number,
-    'icon-allow-overlap'?: boolean,
-    'icon-anchor'?: 'center' | 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right',
-    'text-field'?: string[],
-    'text-size'?: number,
-    'text-justify'?: 'auto' | 'left' | 'center' | 'right',
-    'text-anchor'?: 'center' | 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right',
-  },
-  paint?: {
-    'text-color'?: string,
-    'text-opacity'?: number,
-    'text-halo-color'?: string,
-    'text-halo-width'?: number,
-  },
-}
 
 export type PartialLayerStyle =
   | PartialLineLayer

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     "paths": {
       "@/*": [
         "src/*"
+      ],
+      "@mapLib/*": [
+        "src/core/map/maplibre/*"
       ]
     },
     "declaration": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(() => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
+        '@mapLib': path.resolve(__dirname, './src/core/map/maplibre')
       },
     },
     plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(() => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
-        '@mapLib': path.resolve(__dirname, './src/core/map/maplibre')
+        '@mapLib': path.resolve(__dirname, `./src/core/map/${baseMap}`)
       },
     },
     plugins: [


### PR DESCRIPTION
Hi,

This PR updates the custom layer types (`PartialLineLayer`, `PartialSymbolLayer`) to follow the MapLibre Style Specification, by reusing the types provided by maplibre-gl. fix #37 

This improves type safety and brings consistency with MapLibre’s style system, thanks to the `@mapLib/*` alias (`tsconfig.json`, `vite.config.ts`).

This change affects only TypeScript typings and does not impact runtime behavior.