### PR TITLE
add idPropertyName for geoJson export

### DIFF
--- a/src/core/features/index.ts
+++ b/src/core/features/index.ts
@@ -325,13 +325,16 @@ export class Features {
   exportGeoJson(
     {
       allowedShapes,
+      idPropertyName,
     }: {
       allowedShapes?: Array<FeatureShape>;
+      idPropertyName?: string;
     } = { allowedShapes: undefined },
   ): GeoJsonShapeFeatureCollection {
     return this.asGeoJsonFeatureCollection({
       sourceNames: [SOURCES.main, ...(IS_PRO ? [SOURCES.standby] : [])],
       shapeTypes: allowedShapes ? allowedShapes : [...SHAPE_NAMES],
+      idPropertyName,
     });
   }
 
@@ -354,14 +357,18 @@ export class Features {
   asGeoJsonFeatureCollection({
     shapeTypes,
     sourceNames,
+    idPropertyName,
   }: {
     shapeTypes?: Array<FeatureShape>;
     sourceNames: Array<FeatureSourceName>;
+    idPropertyName?: string;
   }): GeoJsonShapeFeatureCollection {
     const resultFeatureCollection: GeoJsonShapeFeatureCollection = {
       type: 'FeatureCollection',
       features: [],
     };
+
+    idPropertyName ??= FEATURE_ID_PROPERTY;
 
     sourceNames.forEach((sourceName) => {
       const source = this.sources[sourceName];
@@ -378,11 +385,15 @@ export class Features {
               return;
             }
 
+            const id = feature.properties[FEATURE_ID_PROPERTY];
+
+            if (idPropertyName !== FEATURE_ID_PROPERTY) {
+              feature.properties[idPropertyName] = id;
+              delete feature.properties[FEATURE_ID_PROPERTY];
+            }
+
             if (shapeTypes === undefined || shapeTypes.includes(featureData.shape)) {
-              resultFeatureCollection.features.push({
-                ...feature,
-                id: feature.properties[FEATURE_ID_PROPERTY],
-              });
+              resultFeatureCollection.features.push({ ...feature, id });
             }
           });
       }

--- a/src/dev/index.maplibre.dev.ts
+++ b/src/dev/index.maplibre.dev.ts
@@ -84,7 +84,9 @@ const buttonHandlers = {
     if (!geoman) {
       log.warn('Geoman is not initialized');
     }
-    const geojson = geoman.features.exportGeoJson();
+    const geojson = geoman.features.exportGeoJson({
+      idPropertyName: 'uuid',
+    });
     log.debug('total features count: ', geojson?.features?.length);
     log.debug('geojson', JSON.stringify(geojson, null, 2));
   },


### PR DESCRIPTION
Hi @zxwild,

Related to this discussion : https://github.com/geoman-io/maplibre-geoman/issues/56
this PR add an option to customize idPropertyName for geojson exports.
