### PR TITLE
add geoman event declaration to maplibre

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ pack:
   mkdir pub
   cp -r dist pub
   cp package.json pub
+  cp template pub/maplibre-env.d.ts
   cp README.md pub
   cp LICENSE pub
   cp CONTRIBUTING.md pub

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "vite-svg-loader": "^5.1.0"
       },
       "peerDependencies": {
-        "maplibre-gl": "^5.7.1"
+        "maplibre-gl": "^5.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.1.0.tgz",
-      "integrity": "sha512-VLmx4+ceP9XKwPvkjqfnwuHGzgp2MHGpRSWLisvotx6bnUgZLiIfwlVv5nVUlwK/IQoj1KFkrvppzVameZnRhA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.2.0.tgz",
+      "integrity": "sha512-cE80g83fRcBbZbQC70siOUxUK6YJ/5ZkClDZbmm+hzrUbv+J6yntkMmcpdz9DbOrWOM7FHKR5rruc6Q/hWx5cA==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -5978,9 +5978,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.2.tgz",
-      "integrity": "sha512-SU6VlQ1tPskqzcTrwrvOarj2m5HuSkZARSzxbGUAym6h93ygqP6iwofbkzyIr1u6iv82BYK+dCV6avkUDAtwXg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.8.0.tgz",
+      "integrity": "sha512-zLblPFK+z5sxeitDF8RL2cnqfRaivNwxbGoQMfwAm9st6d1lRGTxgI7NNNr/U1AEPkp5+X+wjROagiHvJD8aqg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -5991,7 +5991,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.2.0",
         "@maplibre/vt-pbf": "^4.0.3",
         "@types/geojson": "^7946.0.16",
         "@types/geojson-vt": "3.2.5",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "type-fest": "^4.41.0"
   },
   "peerDependencies": {
-    "maplibre-gl": "^5.7.1"
+    "maplibre-gl": "^5.8.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.3.2",

--- a/src/maplibre-env.d.ts
+++ b/src/maplibre-env.d.ts
@@ -1,0 +1,6 @@
+import type { EventsMap } from './types';
+
+declare module 'maplibre-gl' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface MapEventType extends EventsMap {}
+}

--- a/src/types/map/events-map.ts
+++ b/src/types/map/events-map.ts
@@ -22,7 +22,7 @@ import type {
 } from '@/types';
 import type { BaseMapEvent } from '@mapLib/types/events.ts';
 
-type EventsMap = Record<`${typeof GM_SYSTEM_PREFIX}:draw`, GmDrawEvent> &
+export type EventsMap = Record<`${typeof GM_SYSTEM_PREFIX}:draw`, GmDrawEvent> &
   Record<`${typeof GM_SYSTEM_PREFIX}:edit`, GmEditEvent> &
   Record<`${typeof GM_SYSTEM_PREFIX}:helper`, GmHelperEvent> &
   Record<`${typeof GM_SYSTEM_PREFIX}:control`, GmControlEvent> &

--- a/template
+++ b/template
@@ -1,0 +1,5 @@
+import { EventsMap } from './dist/maplibre-geoman';
+
+declare module 'maplibre-gl' {
+  export interface MapEventType extends EventsMap {}
+}


### PR DESCRIPTION
Hi @zxwild 👋,

Related to issue #52 and based on MapLibre v5.8.0 [#6436](https://github.com/maplibre/maplibre-gl-js/pull/6436)

This PR improves the developer experience for `maplibre-gl` users by merging the `EventsMap` from `geoman` with the `MapEventType` from `maplibre-gl`.  

With this change, all the end user needs to do is create a `maplibre-env.d.ts` file containing the following line:  

```ts
/// <reference types="@geoman-io/maplibre-geoman-free/maplibre-env" />
```

After that, users no longer need to call geoman.mapAdapter.on to benefit from type-safe event listener declarations. For example:

```ts
import maplibre from "maplibre-gl";

const map = new maplibre.Map({
  container: document.getElementById("app")!,
});

map.on("gm:change", (event) => {
  // FeatureUpdatedFwdEvent
  event
});
```
<img width="1245" height="266" alt="env" src="https://github.com/user-attachments/assets/d1c9985e-3084-47a5-a870-c29d39bb7e65" />

Feel free to move the template file whenever you want. Or, if you know how to compile this file directly from `src/maplibre-env.d.ts`, please let me know, as I didn't know how to do it.
 