### PR TITLE
Add optional idGenerator for feature ID creation

### DIFF
--- a/src/core/features/index.ts
+++ b/src/core/features/index.ts
@@ -88,8 +88,13 @@ export class Features {
     }
   }
 
-  getNewFeatureId(): FeatureId {
+  getNewFeatureId(shapeGeoJson: GeoJsonShapeFeature): FeatureId {
     this.featureCounter += 1;
+
+    if (this.gm.options.settings.idGenerator) {
+      return this.gm.options.settings.idGenerator(shapeGeoJson);
+    }
+
     let newFeatureId: FeatureId | null = `feature-${this.featureCounter}`;
 
     while (this.featureStore.has(newFeatureId)) {
@@ -234,7 +239,10 @@ export class Features {
       return null;
     }
 
-    const id = featureId ?? shapeGeoJson.properties[FEATURE_ID_PROPERTY] ?? this.getNewFeatureId();
+    const id =
+      featureId ??
+      shapeGeoJson.properties[FEATURE_ID_PROPERTY] ??
+      this.getNewFeatureId(shapeGeoJson);
 
     if (this.featureStore.get(id)) {
       log.error(

--- a/src/core/options/defaults/free.ts
+++ b/src/core/options/defaults/free.ts
@@ -16,6 +16,7 @@ export const defaultOptions: GmOptionsData = {
       controlContainerClass: 'gm-control-container',
       controlButtonClass: 'gm-control-button',
     },
+    idGenerator: null,
     markerIcons: {
       default: defaultMarker,
       control: defaultShapeMarker,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -11,6 +11,7 @@ import type {
 import type { PartialDeep } from 'type-fest';
 
 import { ACTION_TYPES, MODE_TYPES } from '@/modes/constants.ts';
+import type { GeoJsonShapeFeature } from './geojson';
 
 export type ModeType = (typeof MODE_TYPES)[number];
 export type ActionType = (typeof ACTION_TYPES)[number];
@@ -38,6 +39,7 @@ export type GmOptionsData = {
     controlsUiEnabledByDefault: boolean;
     controlsCollapsible: boolean;
     controlsStyles: ControlStyles;
+    idGenerator: null | ((shapeGeoJson: GeoJsonShapeFeature) => string);
     markerIcons: {
       default: string;
       control: string;


### PR DESCRIPTION
Hi @zxwild ,

I wonder if it can be possible to introduce a new `idGenerator` option that allows customizing how feature IDs are generated ?

Details:

Added an `idGenerator` option in `settings`.

If provided, the function is used to generate the ID of a new feature.

If not provided, the default behavior remains unchanged (`feature-1`, `feature-2`, … with uniqueness check).

The `idGenerator` function receives the GeoJSON feature (GeoJsonShapeFeature) so that ID logic can be based on its properties.

Motivation:

- Provides more flexibility for end users.
- Supports custom ID schemes (UUIDs, business-specific identifiers, timestamps, etc.).
- Backward compatible: if no option is configured, the system continues generating IDs in the form of feature-n.