### PR TITLE
add deleteAll method

### DIFF
--- a/src/core/features/index.ts
+++ b/src/core/features/index.ts
@@ -175,6 +175,13 @@ export class Features {
     }
   }
 
+  deleteAll() {
+    this.featureStore.forEach((featureData) => {
+      featureData.delete();
+    });
+    this.featureStore.clear();
+  }
+
   getFeatureByMouseEvent({
     event,
     sourceNames,


### PR DESCRIPTION
Hi !

I wonder if it can be possible to add a deleteAll() method to FeatureManager to handle full cleanup safely.
Since each featureData.delete() call removes its entry from featureStore, iterating with forEach could lead to inconsistent behavior.
This method ensures all features are deleted and the store is properly cleared.