### PR TITLE
fix #91 replace target property name to mode in GmControlEvent

### DIFF
--- a/src/core/events/listeners/base.ts
+++ b/src/core/events/listeners/base.ts
@@ -110,7 +110,7 @@ export abstract class BaseEventListener {
       modeName = payload.mode;
     } else if (isGmControlEvent(payload)) {
       sectionName = payload.section;
-      modeName = payload.target;
+      modeName = payload.mode;
     }
 
     return sectionName && modeName ? { sectionName, modeName } : null;

--- a/src/core/options/index.ts
+++ b/src/core/options/index.ts
@@ -190,7 +190,7 @@ export class GmOptions {
       level: 'system',
       actionType: 'control',
       section: sectionName,
-      target: modeName,
+      mode: modeName,
       action,
     };
     this.gm.events.fire(`${GM_SYSTEM_PREFIX}:control`, payload);

--- a/src/types/events/control.ts
+++ b/src/types/events/control.ts
@@ -9,7 +9,7 @@ export interface GmControlSwitchEvent extends GmBaseEvent {
   actionType: 'control';
   action: (typeof controlActions)[number];
   section: ModeType;
-  target: ModeName;
+  mode: ModeName;
 }
 
 export interface GmControlLoadEvent extends GmBaseEvent {


### PR DESCRIPTION
Hi,
This pr fix #91 by choosing another name for `modeName` in `GmControlEvent`.