### PR TITLE
fix drawing rectangle initial geometry

### DIFF
--- a/src/modes/draw/rectangle.ts
+++ b/src/modes/draw/rectangle.ts
@@ -144,7 +144,7 @@ export class DrawRectangle extends BaseDraw {
 
   getFeatureGeoJson(bounds: BBox): GeoJsonShapeFeature {
     const rectangleGeoJson = twoCoordsToGeoJsonRectangle(
-      [bounds[0], bounds[2]],
+      [bounds[0], bounds[1]],
       [bounds[2], bounds[3]],
     );
 


### PR DESCRIPTION
Hi,
This is a minor fix for an error that was being logged when starting to draw a rectangle in a region where the longitude is greater than 90.