### PR TITLE
fix: proper cleanup for React StrictMode compatibility

### DIFF
--- a/src/utils/draw/line-drawer.ts
+++ b/src/utils/draw/line-drawer.ts
@@ -114,6 +114,13 @@ export class LineDrawer extends BaseDraw {
     this.gm.markerPointer.disable();
     this.endShape();
     this.snapGuidesInstance?.removeSnapGuides();
+    this.clearDrawerHandlers();
+  }
+
+  clearDrawerHandlers() {
+    this.drawerEventHandlers.firstMarkerClick = null;
+    this.drawerEventHandlers.lastMarkerClick = null;
+    this.drawerEventHandlers.nMarkerClick = null;
   }
 
   handleGmHelperEvent(event: GmSystemEvent): MapHandlerReturnData {


### PR DESCRIPTION
## Summary

Fixes issue #82 by implementing proper initialization and cleanup mechanisms for React StrictMode compatibility.

When `destroy()` is called before initialization completes, the library now gracefully cancels pending async operations and performs synchronous cleanup instead of hanging or throwing "Map adapter is not initialized" errors.

## Changes

- Added `destroyed` flag to track destruction state and cancel pending initialization
- Made cleanup synchronous: removes gm reference from map and detaches events immediately
- Added destruction checks at key async boundaries to prevent operations after cleanup
- Clear LineDrawer event handlers on endAction to prevent stale callbacks across remounts

## Test Plan

- TypeScript compilation passes
- ESLint validation passes
- Build succeeds with no errors
