### PR TITLE
feat: Add interactive dev panels with settings and debugging tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,19 +7,9 @@
   <title>Geoman plugin</title>
 </head>
 <body>
-  <div id="test-controls" style="
-    position: absolute;
-    z-index: 1000;
-    margin: 15px;
-    right: 0;
-    ">
-    <button id="b01">Add controls</button>
-    <button id="b02">Remove controls</button>
-    <button id="b03">Test</button>
-    <button id="b04">Get GeoJSON</button>
-    <button id="b05">On/Off</button>
-  </div>
+  <div id="dev-left-panel"></div>
   <div id="dev-map"></div>
+  <div id="dev-right-panel"></div>
 
   <script type="module" src="/src/main.ts"></script>
   <script type="module" src="/src/dev/index.ts"></script>

--- a/src/dev/components/LeftPanel.svelte
+++ b/src/dev/components/LeftPanel.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  import type {
+    Geoman,
+    DrawModeName,
+    EditModeName,
+    HelperModeName,
+  } from '@/main.ts';
+  import { DRAW_MODES, EDIT_MODES, HELPER_MODES } from '@/modes/constants.ts';
+
+  interface Props {
+    geoman: Geoman | null;
+  }
+
+  let { geoman }: Props = $props();
+
+  // Section collapse states
+  let settingsExpanded = $state(true);
+  let drawModesExpanded = $state(true);
+  let editModesExpanded = $state(true);
+  let helperModesExpanded = $state(true);
+
+  // Settings state
+  let throttlingDelay = $state(10);
+  let awaitDataUpdates = $state(true);
+  let snappingEnabled = $state(false);
+  let snappingDistance = $state(20);
+  let allowSelfIntersection = $state(true);
+
+  // Active modes tracking
+  let activeDrawModes = $state<DrawModeName[]>([]);
+  let activeEditModes = $state<EditModeName[]>([]);
+  let activeHelperModes = $state<HelperModeName[]>([]);
+
+  // Sync settings from geoman when it changes
+  $effect(() => {
+    if (geoman) {
+      activeDrawModes = geoman.getActiveDrawModes();
+      activeEditModes = geoman.getActiveEditModes();
+      activeHelperModes = geoman.getActiveHelperModes();
+    }
+  });
+
+  const toggleSection = (section: string) => {
+    switch (section) {
+      case 'settings':
+        settingsExpanded = !settingsExpanded;
+        break;
+      case 'draw':
+        drawModesExpanded = !drawModesExpanded;
+        break;
+      case 'edit':
+        editModesExpanded = !editModesExpanded;
+        break;
+      case 'helper':
+        helperModesExpanded = !helperModesExpanded;
+        break;
+    }
+  };
+
+  const toggleDrawMode = (mode: DrawModeName) => {
+    if (!geoman) return;
+    const isAvailable = geoman.options.isModeAvailable('draw', mode);
+    if (!isAvailable) return;
+
+    geoman.options.toggleMode('draw', mode);
+    activeDrawModes = geoman.getActiveDrawModes();
+    activeEditModes = geoman.getActiveEditModes();
+    activeHelperModes = geoman.getActiveHelperModes();
+  };
+
+  const toggleEditMode = (mode: EditModeName) => {
+    if (!geoman) return;
+    const isAvailable = geoman.options.isModeAvailable('edit', mode);
+    if (!isAvailable) return;
+
+    geoman.options.toggleMode('edit', mode);
+    activeDrawModes = geoman.getActiveDrawModes();
+    activeEditModes = geoman.getActiveEditModes();
+    activeHelperModes = geoman.getActiveHelperModes();
+  };
+
+  const toggleHelperMode = (mode: HelperModeName) => {
+    if (!geoman) return;
+    const isAvailable = geoman.options.isModeAvailable('helper', mode);
+    if (!isAvailable) return;
+
+    geoman.options.toggleMode('helper', mode);
+    activeDrawModes = geoman.getActiveDrawModes();
+    activeEditModes = geoman.getActiveEditModes();
+    activeHelperModes = geoman.getActiveHelperModes();
+  };
+
+  const disableAllModes = () => {
+    if (!geoman) return;
+    geoman.disableAllModes();
+    activeDrawModes = [];
+    activeEditModes = [];
+    activeHelperModes = [];
+  };
+
+  const isModeAvailable = (
+    type: 'draw' | 'edit' | 'helper',
+    mode: DrawModeName | EditModeName | HelperModeName,
+  ): boolean => {
+    if (!geoman) return false;
+    return geoman.options.isModeAvailable(type, mode);
+  };
+
+  const formatModeName = (mode: string): string => {
+    return mode.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  };
+</script>
+
+<div class="dev-panel-header">
+  <span>Settings & Controls</span>
+</div>
+
+<div class="dev-panel-content">
+  <!-- Global Settings Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!settingsExpanded}
+      onclick={() => toggleSection('settings')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('settings')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Global Settings</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!settingsExpanded}>
+      <div class="dev-control-row">
+        <label for="throttle-delay">Throttle Delay (ms)</label>
+        <input
+          id="throttle-delay"
+          type="number"
+          class="dev-input"
+          bind:value={throttlingDelay}
+          min="0"
+          max="1000"
+        />
+      </div>
+
+      <div class="dev-control-row">
+        <label for="await-updates">Await Data Updates</label>
+        <label class="dev-toggle">
+          <input type="checkbox" id="await-updates" bind:checked={awaitDataUpdates} />
+          <span class="dev-toggle-slider"></span>
+        </label>
+      </div>
+
+      <div class="dev-control-row">
+        <label for="snapping">Snapping</label>
+        <label class="dev-toggle">
+          <input
+            type="checkbox"
+            id="snapping"
+            bind:checked={snappingEnabled}
+            onchange={() => {
+              if (geoman && snappingEnabled) {
+                toggleHelperMode('snapping');
+              }
+            }}
+          />
+          <span class="dev-toggle-slider"></span>
+        </label>
+      </div>
+
+      <div class="dev-control-row">
+        <label for="snap-distance">Snap Distance (px)</label>
+        <input
+          id="snap-distance"
+          type="number"
+          class="dev-input"
+          bind:value={snappingDistance}
+          min="1"
+          max="100"
+        />
+      </div>
+
+      <div class="dev-control-row">
+        <label for="self-intersect">Allow Self Intersection</label>
+        <label class="dev-toggle">
+          <input type="checkbox" id="self-intersect" bind:checked={allowSelfIntersection} />
+          <span class="dev-toggle-slider"></span>
+        </label>
+      </div>
+
+      <div class="dev-btn-row">
+        <button class="dev-btn danger" onclick={disableAllModes}>Disable All Modes</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Draw Modes Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!drawModesExpanded}
+      onclick={() => toggleSection('draw')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('draw')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Draw Modes</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!drawModesExpanded}>
+      <div class="dev-mode-grid">
+        {#each DRAW_MODES as mode}
+          {@const isActive = activeDrawModes.includes(mode)}
+          {@const isAvailable = isModeAvailable('draw', mode)}
+          <button
+            class="dev-mode-btn"
+            class:active={isActive}
+            class:disabled={!isAvailable}
+            onclick={() => toggleDrawMode(mode)}
+            title={isAvailable ? `Toggle ${mode} mode` : `${mode} mode not available`}
+          >
+            {formatModeName(mode)}
+          </button>
+        {/each}
+      </div>
+    </div>
+  </div>
+
+  <!-- Edit Modes Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!editModesExpanded}
+      onclick={() => toggleSection('edit')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('edit')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Edit Modes</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!editModesExpanded}>
+      <div class="dev-mode-grid">
+        {#each EDIT_MODES as mode}
+          {@const isActive = activeEditModes.includes(mode)}
+          {@const isAvailable = isModeAvailable('edit', mode)}
+          <button
+            class="dev-mode-btn"
+            class:active={isActive}
+            class:disabled={!isAvailable}
+            onclick={() => toggleEditMode(mode)}
+            title={isAvailable ? `Toggle ${mode} mode` : `${mode} mode not available`}
+          >
+            {formatModeName(mode)}
+          </button>
+        {/each}
+      </div>
+    </div>
+  </div>
+
+  <!-- Helper Modes Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!helperModesExpanded}
+      onclick={() => toggleSection('helper')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('helper')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Helper Modes</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!helperModesExpanded}>
+      <div class="dev-mode-grid">
+        {#each HELPER_MODES as mode}
+          {@const isActive = activeHelperModes.includes(mode)}
+          {@const isAvailable = isModeAvailable('helper', mode)}
+          <button
+            class="dev-mode-btn"
+            class:active={isActive}
+            class:disabled={!isAvailable}
+            onclick={() => toggleHelperMode(mode)}
+            title={isAvailable ? `Toggle ${mode} mode` : `${mode} mode not available`}
+          >
+            {formatModeName(mode)}
+          </button>
+        {/each}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="dev-shortcuts-hint">
+  <kbd>Ctrl</kbd>+<kbd>1</kbd> Toggle left panel
+</div>

--- a/src/dev/components/RightPanel.svelte
+++ b/src/dev/components/RightPanel.svelte
@@ -1,0 +1,678 @@
+<script lang="ts">
+  import type { Geoman, GeoJsonImportFeature } from '@/main.ts';
+  import type { Map as MaplibreMap } from 'maplibre-gl';
+  import commonShapes from '@tests/fixtures/common-shapes.json';
+  import oneOfEachShape from '@tests/fixtures/one-shape-of-each-type.json';
+  import {
+    loadStressTestFeatureCollection,
+    loadStressTestCircleMarkers,
+  } from '@/dev/fixtures/shapes.ts';
+
+  interface Props {
+    geoman: Geoman | null;
+    map: MaplibreMap | null;
+  }
+
+  interface EventLogEntry {
+    id: number;
+    time: string;
+    name: string;
+    data?: string;
+  }
+
+  interface SourceInfo {
+    name: string;
+    featureCount: number;
+    isInternal: boolean;
+  }
+
+  interface LayerInfo {
+    id: string;
+    type: string;
+    source: string;
+    isInternal: boolean;
+  }
+
+  let { geoman, map }: Props = $props();
+
+  // Section collapse states
+  let layersExpanded = $state(true);
+  let shapesExpanded = $state(true);
+  let geojsonExpanded = $state(true);
+  let eventsExpanded = $state(false);
+  let debugExpanded = $state(true);
+
+  // Layer group collapse states
+  let gmSourcesExpanded = $state(true);
+  let otherSourcesExpanded = $state(false);
+  let gmLayersExpanded = $state(false);
+  let otherLayersExpanded = $state(false);
+
+  // GeoJSON textarea content
+  let geojsonInput = $state('');
+  let prettyPrint = $state(true);
+
+  // Event log state
+  let eventLog = $state<EventLogEntry[]>([]);
+  let eventLoggingEnabled = $state(true);
+  let eventIdCounter = $state(0);
+  let eventFilters = $state({
+    create: true,
+    update: true,
+    remove: true,
+    draw: true,
+    edit: true,
+    mode: true,
+  });
+
+  // Debug info
+  let cursorLng = $state(0);
+  let cursorLat = $state(0);
+  let featureCount = $state(0);
+  let currentMode = $state('none');
+
+  // Layer/Source info
+  let sources = $state<SourceInfo[]>([]);
+  let layers = $state<LayerInfo[]>([]);
+  let lastLayerUpdate = $state('');
+
+  // Track registered listeners
+  let listenersRegistered = $state(false);
+
+  const toggleSection = (section: string) => {
+    switch (section) {
+      case 'layers':
+        layersExpanded = !layersExpanded;
+        break;
+      case 'shapes':
+        shapesExpanded = !shapesExpanded;
+        break;
+      case 'geojson':
+        geojsonExpanded = !geojsonExpanded;
+        break;
+      case 'events':
+        eventsExpanded = !eventsExpanded;
+        break;
+      case 'debug':
+        debugExpanded = !debugExpanded;
+        break;
+    }
+  };
+
+  // Event logging
+  const logEvent = (name: string, data?: unknown) => {
+    if (!eventLoggingEnabled) return;
+
+    // Check filters
+    if (name.includes('create') && !eventFilters.create) return;
+    if (name.includes('update') && !eventFilters.update) return;
+    if (name.includes('remove') && !eventFilters.remove) return;
+    if (name.includes('draw') && !eventFilters.draw) return;
+    if ((name.includes('drag') || name.includes('change') || name.includes('rotate')) && !eventFilters.edit) return;
+    if (name.includes('mode') && !eventFilters.mode) return;
+
+    const time = new Date().toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+
+    eventLog = [
+      {
+        id: eventIdCounter++,
+        time,
+        name,
+        data: data ? JSON.stringify(data, null, 2).slice(0, 500) : undefined,
+      },
+      ...eventLog.slice(0, 99), // Keep last 100 events
+    ];
+  };
+
+  const clearEventLog = () => {
+    eventLog = [];
+  };
+
+  const toggleEventFilter = (filter: keyof typeof eventFilters) => {
+    eventFilters[filter] = !eventFilters[filter];
+  };
+
+  // Register event listeners when geoman changes
+  $effect(() => {
+    if (!geoman || !map || listenersRegistered) return;
+
+    const events = [
+      'gm:create',
+      'gm:update',
+      'gm:remove',
+      'gm:drawstart',
+      'gm:drawend',
+      'gm:dragstart',
+      'gm:drag',
+      'gm:dragend',
+      'gm:globaldrawmodetoggled',
+      'gm:globaldragmodetoggled',
+      'gm:globalchangemodetoggled',
+      'gm:globalrotatemodetoggled',
+      'gm:globalcutmodetoggled',
+      'gm:globaldeletemodetoggled',
+    ];
+
+    events.forEach((eventName) => {
+      map.on(eventName, (e: { type: string; feature?: { id?: string }; action?: string }) => {
+        const eventData = {
+          type: e.type,
+          featureId: e.feature?.id,
+          action: e.action,
+        };
+        logEvent(eventName, eventData);
+        updateDebugInfo();
+      });
+    });
+
+    // Track mouse position
+    map.on('mousemove', (e) => {
+      cursorLng = Math.round(e.lngLat.lng * 10000) / 10000;
+      cursorLat = Math.round(e.lngLat.lat * 10000) / 10000;
+    });
+
+    // Initial layer info update
+    updateLayerInfo();
+
+    // Set up interval for live updates
+    setInterval(updateLayerInfo, 1000);
+
+    listenersRegistered = true;
+  });
+
+  const updateLayerInfo = () => {
+    if (!map) return;
+
+    const style = map.getStyle();
+    if (!style) return;
+
+    // Get all sources
+    const sourceEntries = Object.entries(style.sources || {});
+    const newSources: SourceInfo[] = [];
+
+    for (const [name] of sourceEntries) {
+      const isInternal = name.startsWith('gm_');
+      let featureCount = 0;
+
+      try {
+        const source = map.getSource(name);
+        if (source && 'serialize' in source) {
+          const serialized = (source as { serialize: () => { data?: { features?: unknown[] } } }).serialize();
+          if (serialized?.data && 'features' in serialized.data) {
+            featureCount = (serialized.data.features as unknown[])?.length || 0;
+          }
+        }
+      } catch {
+        // Some sources don't support serialize
+      }
+
+      newSources.push({
+        name,
+        featureCount,
+        isInternal,
+      });
+    }
+
+    // Sort: gm_ sources first, then alphabetically
+    newSources.sort((a, b) => {
+      if (a.isInternal && !b.isInternal) return -1;
+      if (!a.isInternal && b.isInternal) return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    sources = newSources;
+
+    // Get all layers
+    const newLayers: LayerInfo[] = (style.layers || []).map((layer) => ({
+      id: layer.id,
+      type: layer.type,
+      source: 'source' in layer ? String(layer.source) : '',
+      isInternal: layer.id.startsWith('gm_') || ('source' in layer && String(layer.source).startsWith('gm_')),
+    }));
+
+    layers = newLayers;
+
+    lastLayerUpdate = new Date().toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  };
+
+  const updateDebugInfo = () => {
+    if (!geoman) return;
+
+    const drawModes = geoman.getActiveDrawModes();
+    const editModes = geoman.getActiveEditModes();
+
+    if (drawModes.length > 0) {
+      currentMode = `draw:${drawModes.join(',')}`;
+    } else if (editModes.length > 0) {
+      currentMode = `edit:${editModes.join(',')}`;
+    } else {
+      currentMode = 'none';
+    }
+
+    try {
+      const geoJson = geoman.features.exportGeoJson();
+      featureCount = geoJson?.features?.length || 0;
+    } catch {
+      featureCount = 0;
+    }
+  };
+
+  // Shape loaders
+  const loadCommonShapes = () => {
+    if (!geoman) return;
+    geoman.features.importGeoJson({
+      type: 'FeatureCollection',
+      features: commonShapes as GeoJsonImportFeature[],
+    });
+    updateDebugInfo();
+    logEvent('shapes:loaded', { type: 'common-shapes', count: commonShapes.length });
+  };
+
+  const loadOneOfEach = () => {
+    if (!geoman) return;
+    geoman.features.importGeoJson({
+      type: 'FeatureCollection',
+      features: oneOfEachShape as GeoJsonImportFeature[],
+    });
+    updateDebugInfo();
+    logEvent('shapes:loaded', { type: 'one-of-each', count: oneOfEachShape.length });
+  };
+
+  const loadStressTest = () => {
+    if (!geoman) return;
+    loadStressTestFeatureCollection(geoman, 0.5, 0.4);
+    updateDebugInfo();
+    logEvent('shapes:loaded', { type: 'stress-test-polygons' });
+  };
+
+  const loadMarkerStressTest = () => {
+    if (!geoman) return;
+    loadStressTestCircleMarkers(geoman, 0.5);
+    updateDebugInfo();
+    logEvent('shapes:loaded', { type: 'stress-test-markers' });
+  };
+
+  const clearAllShapes = () => {
+    if (!geoman) return;
+    const geoJson = geoman.features.exportGeoJson();
+    const featureIds = geoJson?.features?.map((f) => f.id).filter(Boolean) || [];
+    featureIds.forEach((id) => {
+      try {
+        const feature = geoman.features.get('gm_main', id as string);
+        feature?.delete();
+      } catch {
+        // ignore
+      }
+    });
+    updateDebugInfo();
+    logEvent('shapes:cleared', { count: featureIds.length });
+  };
+
+  // GeoJSON tools
+  const exportGeoJson = () => {
+    if (!geoman) return;
+    const geoJson = geoman.features.exportGeoJson();
+    geojsonInput = prettyPrint ? JSON.stringify(geoJson, null, 2) : JSON.stringify(geoJson);
+    logEvent('geojson:exported', { featureCount: geoJson?.features?.length || 0 });
+  };
+
+  const copyToClipboard = () => {
+    if (!geoman) return;
+    const geoJson = geoman.features.exportGeoJson();
+    const text = prettyPrint ? JSON.stringify(geoJson, null, 2) : JSON.stringify(geoJson);
+    navigator.clipboard.writeText(text);
+    logEvent('geojson:copied', { featureCount: geoJson?.features?.length || 0 });
+  };
+
+  const importGeoJson = () => {
+    if (!geoman || !geojsonInput.trim()) return;
+    try {
+      const parsed = JSON.parse(geojsonInput);
+      geoman.features.importGeoJson(parsed);
+      updateDebugInfo();
+      logEvent('geojson:imported', { featureCount: parsed?.features?.length || 1 });
+    } catch (e) {
+      logEvent('geojson:import-error', { error: String(e) });
+    }
+  };
+
+  const clearGeoJsonInput = () => {
+    geojsonInput = '';
+  };
+</script>
+
+<div class="dev-panel-header">
+  <span>Data & Debugging</span>
+</div>
+
+<div class="dev-panel-content">
+  <!-- Layer Summary Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!layersExpanded}
+      onclick={() => toggleSection('layers')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('layers')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Sources & Layers</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!layersExpanded}>
+      <div class="dev-layer-summary">
+        <!-- Geoman Sources -->
+        <div class="dev-layer-group">
+          <div
+            class="dev-layer-group-header internal clickable"
+            class:collapsed={!gmSourcesExpanded}
+            onclick={() => gmSourcesExpanded = !gmSourcesExpanded}
+            onkeydown={(e) => e.key === 'Enter' && (gmSourcesExpanded = !gmSourcesExpanded)}
+            role="button"
+            tabindex="0"
+          >
+            <span><span class="toggle-icon">&#9660;</span> Geoman Sources</span>
+            <span class="count">{sources.filter(s => s.isInternal).reduce((sum, s) => sum + s.featureCount, 0)}</span>
+          </div>
+          {#if gmSourcesExpanded}
+            {#each sources.filter(s => s.isInternal) as source}
+              <div class="dev-layer-item internal">
+                <span class="name">{source.name}</span>
+                <span class="count">{source.featureCount} features</span>
+              </div>
+            {/each}
+            {#if sources.filter(s => s.isInternal).length === 0}
+              <div class="dev-layer-item">
+                <span class="name" style="color: #888; font-style: italic;">No Geoman sources</span>
+              </div>
+            {/if}
+          {/if}
+        </div>
+
+        <!-- Other Sources -->
+        <div class="dev-layer-group">
+          <div
+            class="dev-layer-group-header clickable"
+            class:collapsed={!otherSourcesExpanded}
+            onclick={() => otherSourcesExpanded = !otherSourcesExpanded}
+            onkeydown={(e) => e.key === 'Enter' && (otherSourcesExpanded = !otherSourcesExpanded)}
+            role="button"
+            tabindex="0"
+          >
+            <span><span class="toggle-icon">&#9660;</span> Other Sources</span>
+            <span class="count">{sources.filter(s => !s.isInternal).length}</span>
+          </div>
+          {#if otherSourcesExpanded}
+            {#each sources.filter(s => !s.isInternal) as source}
+              <div class="dev-layer-item">
+                <span class="name">{source.name}</span>
+                <span class="count">{source.featureCount > 0 ? `${source.featureCount} features` : '-'}</span>
+              </div>
+            {/each}
+            {#if sources.filter(s => !s.isInternal).length === 0}
+              <div class="dev-layer-item">
+                <span class="name" style="color: #888; font-style: italic;">No other sources</span>
+              </div>
+            {/if}
+          {/if}
+        </div>
+
+        <!-- Geoman Layers -->
+        <div class="dev-layer-group">
+          <div
+            class="dev-layer-group-header internal clickable"
+            class:collapsed={!gmLayersExpanded}
+            onclick={() => gmLayersExpanded = !gmLayersExpanded}
+            onkeydown={(e) => e.key === 'Enter' && (gmLayersExpanded = !gmLayersExpanded)}
+            role="button"
+            tabindex="0"
+          >
+            <span><span class="toggle-icon">&#9660;</span> Geoman Layers</span>
+            <span class="count">{layers.filter(l => l.isInternal).length}</span>
+          </div>
+          {#if gmLayersExpanded}
+            {#each layers.filter(l => l.isInternal) as layer}
+              <div class="dev-layer-item internal">
+                <span class="name">{layer.id}</span>
+                <span class="count">{layer.type}</span>
+              </div>
+            {/each}
+            {#if layers.filter(l => l.isInternal).length === 0}
+              <div class="dev-layer-item">
+                <span class="name" style="color: #888; font-style: italic;">No Geoman layers</span>
+              </div>
+            {/if}
+          {/if}
+        </div>
+
+        <!-- Other Layers -->
+        <div class="dev-layer-group">
+          <div
+            class="dev-layer-group-header clickable"
+            class:collapsed={!otherLayersExpanded}
+            onclick={() => otherLayersExpanded = !otherLayersExpanded}
+            onkeydown={(e) => e.key === 'Enter' && (otherLayersExpanded = !otherLayersExpanded)}
+            role="button"
+            tabindex="0"
+          >
+            <span><span class="toggle-icon">&#9660;</span> Other Layers</span>
+            <span class="count">{layers.filter(l => !l.isInternal).length}</span>
+          </div>
+          {#if otherLayersExpanded}
+            {#each layers.filter(l => !l.isInternal).slice(0, 10) as layer}
+              <div class="dev-layer-item">
+                <span class="name">{layer.id}</span>
+                <span class="count">{layer.type}</span>
+              </div>
+            {/each}
+            {#if layers.filter(l => !l.isInternal).length > 10}
+              <div class="dev-layer-item">
+                <span class="name" style="color: #888; font-style: italic;">...and {layers.filter(l => !l.isInternal).length - 10} more</span>
+              </div>
+            {/if}
+          {/if}
+        </div>
+      </div>
+      <div class="dev-refresh-indicator">Last update: {lastLayerUpdate}</div>
+      <button class="dev-btn" onclick={updateLayerInfo}>Refresh Now</button>
+    </div>
+  </div>
+
+  <!-- Shape Loaders Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!shapesExpanded}
+      onclick={() => toggleSection('shapes')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('shapes')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Shape Loaders</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!shapesExpanded}>
+      <div class="dev-btn-row">
+        <button class="dev-btn" onclick={loadCommonShapes}>Common Shapes</button>
+        <button class="dev-btn" onclick={loadOneOfEach}>One of Each</button>
+      </div>
+      <div class="dev-btn-row">
+        <button class="dev-btn" onclick={loadStressTest}>Polygon Grid</button>
+        <button class="dev-btn" onclick={loadMarkerStressTest}>Marker Grid</button>
+      </div>
+      <div class="dev-btn-row">
+        <button class="dev-btn danger" onclick={clearAllShapes}>Clear All Shapes</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- GeoJSON Tools Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!geojsonExpanded}
+      onclick={() => toggleSection('geojson')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('geojson')}
+      role="button"
+      tabindex="0"
+    >
+      <span>GeoJSON Tools</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!geojsonExpanded}>
+      <div class="dev-btn-row">
+        <button class="dev-btn" onclick={exportGeoJson}>Dump GeoJSON</button>
+        <button class="dev-btn" onclick={copyToClipboard}>Copy to Clipboard</button>
+      </div>
+      <div class="dev-control-row">
+        <label for="pretty-print">Pretty Print</label>
+        <label class="dev-toggle">
+          <input type="checkbox" id="pretty-print" bind:checked={prettyPrint} />
+          <span class="dev-toggle-slider"></span>
+        </label>
+      </div>
+      <textarea
+        class="dev-textarea"
+        bind:value={geojsonInput}
+        placeholder="Paste GeoJSON here to import..."
+      ></textarea>
+      <div class="dev-btn-row">
+        <button class="dev-btn primary" onclick={importGeoJson}>Import GeoJSON</button>
+        <button class="dev-btn" onclick={clearGeoJsonInput}>Clear</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Event Logger Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!eventsExpanded}
+      onclick={() => toggleSection('events')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('events')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Event Logger</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!eventsExpanded}>
+      <div class="dev-control-row">
+        <label for="event-logging">Enable Logging</label>
+        <label class="dev-toggle">
+          <input type="checkbox" id="event-logging" bind:checked={eventLoggingEnabled} />
+          <span class="dev-toggle-slider"></span>
+        </label>
+      </div>
+      <div class="dev-filter-row">
+        <button
+          class="dev-filter-btn"
+          class:active={eventFilters.create}
+          onclick={() => toggleEventFilter('create')}
+        >
+          create
+        </button>
+        <button
+          class="dev-filter-btn"
+          class:active={eventFilters.update}
+          onclick={() => toggleEventFilter('update')}
+        >
+          update
+        </button>
+        <button
+          class="dev-filter-btn"
+          class:active={eventFilters.remove}
+          onclick={() => toggleEventFilter('remove')}
+        >
+          remove
+        </button>
+        <button
+          class="dev-filter-btn"
+          class:active={eventFilters.draw}
+          onclick={() => toggleEventFilter('draw')}
+        >
+          draw
+        </button>
+        <button
+          class="dev-filter-btn"
+          class:active={eventFilters.edit}
+          onclick={() => toggleEventFilter('edit')}
+        >
+          edit
+        </button>
+        <button
+          class="dev-filter-btn"
+          class:active={eventFilters.mode}
+          onclick={() => toggleEventFilter('mode')}
+        >
+          mode
+        </button>
+      </div>
+      <div class="dev-event-log">
+        {#each eventLog as event (event.id)}
+          <div class="dev-event-log-item">
+            <span class="dev-event-log-time">{event.time}</span>
+            <span class="dev-event-log-name">{event.name}</span>
+            {#if event.data}
+              <span class="dev-event-log-data">{event.data}</span>
+            {/if}
+          </div>
+        {/each}
+        {#if eventLog.length === 0}
+          <div class="dev-feature-info-empty">No events logged yet</div>
+        {/if}
+      </div>
+      <button class="dev-btn" onclick={clearEventLog}>Clear Log</button>
+    </div>
+  </div>
+
+  <!-- Debug Info Section -->
+  <div class="dev-section">
+    <div
+      class="dev-section-header"
+      class:collapsed={!debugExpanded}
+      onclick={() => toggleSection('debug')}
+      onkeydown={(e) => e.key === 'Enter' && toggleSection('debug')}
+      role="button"
+      tabindex="0"
+    >
+      <span>Debug Info</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="dev-section-content" class:collapsed={!debugExpanded}>
+      <div class="dev-debug-info">
+        <div class="dev-debug-row">
+          <span class="dev-debug-label">Current Mode</span>
+          <span class="dev-debug-value">{currentMode}</span>
+        </div>
+        <div class="dev-debug-row">
+          <span class="dev-debug-label">Feature Count</span>
+          <span class="dev-debug-value">{featureCount}</span>
+        </div>
+        <div class="dev-debug-row">
+          <span class="dev-debug-label">Cursor (lng)</span>
+          <span class="dev-debug-value">{cursorLng}</span>
+        </div>
+        <div class="dev-debug-row">
+          <span class="dev-debug-label">Cursor (lat)</span>
+          <span class="dev-debug-value">{cursorLat}</span>
+        </div>
+      </div>
+      <button class="dev-btn" onclick={updateDebugInfo}>Refresh</button>
+    </div>
+  </div>
+</div>
+
+<div class="dev-shortcuts-hint">
+  <kbd>Ctrl</kbd>+<kbd>2</kbd> Toggle right panel
+</div>

--- a/src/dev/styles/style.css
+++ b/src/dev/styles/style.css
@@ -5,10 +5,550 @@ body {
   margin: 0;
   padding: 0;
   background-color: #f1f1f1;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  font-size: 13px;
 }
 
 #dev-map {
   flex: 1 1 auto;
-  /*margin: 8rem;*/
-  /*border-radius: 0.3rem;*/
+  min-width: 0;
+}
+
+/* Panel Base Styles */
+#dev-left-panel,
+#dev-right-panel {
+  flex: 0 0 320px;
+  background: #ffffff;
+  border: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: flex-basis 0.2s ease, opacity 0.2s ease;
+}
+
+#dev-left-panel {
+  border-right: 1px solid #d0d0d0;
+}
+
+#dev-right-panel {
+  border-left: 1px solid #d0d0d0;
+}
+
+#dev-left-panel.collapsed,
+#dev-right-panel.collapsed {
+  flex-basis: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Panel Header */
+.dev-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #f8f9fa;
+  border-bottom: 1px solid #e0e0e0;
+  font-weight: 600;
+  font-size: 14px;
+  color: #333;
+}
+
+.dev-panel-header button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #666;
+}
+
+.dev-panel-header button:hover {
+  background: #e0e0e0;
+}
+
+/* Panel Content */
+.dev-panel-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+}
+
+/* Section Styles */
+.dev-section {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.dev-section:last-child {
+  border-bottom: none;
+}
+
+.dev-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: #fafafa;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #555;
+}
+
+.dev-section-header:hover {
+  background: #f0f0f0;
+}
+
+.dev-section-header .toggle-icon {
+  font-size: 10px;
+  color: #888;
+  transition: transform 0.15s ease;
+}
+
+.dev-section-header.collapsed .toggle-icon {
+  transform: rotate(-90deg);
+}
+
+.dev-section-content {
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dev-section-content.collapsed {
+  display: none;
+}
+
+/* Control Row */
+.dev-control-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.dev-control-row > label:first-child {
+  flex: 1;
+  font-size: 12px;
+  color: #444;
+}
+
+/* Toggle Switch */
+.dev-toggle {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  flex: 0 0 36px;
+}
+
+.dev-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.dev-toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.2s;
+  border-radius: 20px;
+}
+
+.dev-toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.2s;
+  border-radius: 50%;
+}
+
+.dev-toggle input:checked + .dev-toggle-slider {
+  background-color: #4CAF50;
+}
+
+.dev-toggle input:checked + .dev-toggle-slider:before {
+  transform: translateX(16px);
+}
+
+/* Buttons */
+.dev-btn {
+  padding: 8px 12px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  color: #333;
+  transition: all 0.15s ease;
+}
+
+.dev-btn:hover {
+  background: #f5f5f5;
+  border-color: #bbb;
+}
+
+.dev-btn:active {
+  background: #e8e8e8;
+}
+
+.dev-btn.primary {
+  background: #4CAF50;
+  border-color: #4CAF50;
+  color: white;
+}
+
+.dev-btn.primary:hover {
+  background: #45a049;
+}
+
+.dev-btn.danger {
+  background: #f44336;
+  border-color: #f44336;
+  color: white;
+}
+
+.dev-btn.danger:hover {
+  background: #da190b;
+}
+
+.dev-btn-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dev-btn-row .dev-btn {
+  flex: 1;
+  min-width: 80px;
+}
+
+/* Mode Toggles Grid */
+.dev-mode-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dev-mode-btn {
+  padding: 5px 10px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 11px;
+  text-align: center;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.dev-mode-btn:hover {
+  background: #f0f0f0;
+}
+
+.dev-mode-btn.active {
+  background: #e3f2fd;
+  border-color: #2196F3;
+  color: #1976D2;
+}
+
+.dev-mode-btn.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Input styles */
+.dev-input {
+  width: 60px;
+  padding: 4px 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.dev-input:focus {
+  outline: none;
+  border-color: #2196F3;
+}
+
+/* Textarea */
+.dev-textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 11px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.dev-textarea:focus {
+  outline: none;
+  border-color: #2196F3;
+}
+
+/* Event Log */
+.dev-event-log {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 11px;
+  padding: 8px;
+  border-radius: 4px;
+  height: 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.dev-event-log-item {
+  padding: 4px 0;
+  border-bottom: 1px solid #333;
+  word-wrap: break-word;
+}
+
+.dev-event-log-item:last-child {
+  border-bottom: none;
+}
+
+.dev-event-log-time {
+  color: #888;
+  margin-right: 8px;
+}
+
+.dev-event-log-name {
+  color: #569cd6;
+}
+
+.dev-event-log-data {
+  color: #9cdcfe;
+  margin-left: 16px;
+  display: block;
+  white-space: pre-wrap;
+}
+
+/* Debug Info */
+.dev-debug-info {
+  background: #f8f9fa;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 11px;
+}
+
+.dev-debug-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.dev-debug-row:last-child {
+  border-bottom: none;
+}
+
+.dev-debug-label {
+  color: #666;
+}
+
+.dev-debug-value {
+  color: #333;
+  font-weight: 500;
+}
+
+/* Filter controls */
+.dev-filter-row {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.dev-filter-btn {
+  padding: 4px 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 10px;
+}
+
+.dev-filter-btn:hover {
+  background: #f0f0f0;
+}
+
+.dev-filter-btn.active {
+  background: #e3f2fd;
+  border-color: #2196F3;
+}
+
+/* Keyboard shortcuts hint */
+.dev-shortcuts-hint {
+  padding: 8px 16px;
+  background: #f0f0f0;
+  font-size: 11px;
+  color: #666;
+  border-top: 1px solid #e0e0e0;
+}
+
+.dev-shortcuts-hint kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 10px;
+  box-shadow: 0 1px 0 #bbb;
+}
+
+/* Scrollbar styling */
+.dev-panel-content::-webkit-scrollbar,
+.dev-event-log::-webkit-scrollbar,
+.dev-textarea::-webkit-scrollbar {
+  width: 8px;
+}
+
+.dev-panel-content::-webkit-scrollbar-track,
+.dev-event-log::-webkit-scrollbar-track,
+.dev-textarea::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.dev-panel-content::-webkit-scrollbar-thumb,
+.dev-event-log::-webkit-scrollbar-thumb,
+.dev-textarea::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
+}
+
+.dev-panel-content::-webkit-scrollbar-thumb:hover,
+.dev-event-log::-webkit-scrollbar-thumb:hover,
+.dev-textarea::-webkit-scrollbar-thumb:hover {
+  background: #a1a1a1;
+}
+
+/* Feature info display */
+.dev-feature-info {
+  background: #f8f9fa;
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 11px;
+}
+
+.dev-feature-info-empty {
+  color: #888;
+  font-style: italic;
+  text-align: center;
+  padding: 16px;
+}
+
+/* Layer Summary */
+.dev-layer-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dev-layer-group {
+  background: #f8f9fa;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dev-layer-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  background: #e9ecef;
+  font-weight: 500;
+  font-size: 11px;
+}
+
+.dev-layer-group-header.clickable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.dev-layer-group-header.clickable:hover {
+  background: #dee2e6;
+}
+
+.dev-layer-group-header .toggle-icon {
+  font-size: 8px;
+  color: #888;
+  margin-right: 4px;
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+
+.dev-layer-group-header.collapsed .toggle-icon {
+  transform: rotate(-90deg);
+}
+
+.dev-layer-group-header .count {
+  background: #6c757d;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.dev-layer-group-header.internal .count {
+  background: #dc3545;
+}
+
+.dev-layer-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  border-top: 1px solid #e0e0e0;
+  font-size: 11px;
+}
+
+.dev-layer-item:first-child {
+  border-top: none;
+}
+
+.dev-layer-item .name {
+  color: #495057;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+}
+
+.dev-layer-item .count {
+  color: #6c757d;
+  font-weight: 500;
+}
+
+.dev-layer-item.internal {
+  background: #fff5f5;
+}
+
+.dev-layer-item.internal .name {
+  color: #dc3545;
+}
+
+.dev-refresh-indicator {
+  font-size: 10px;
+  color: #888;
+  text-align: right;
+  margin-top: 4px;
 }


### PR DESCRIPTION
## Summary
Implement GitHub issue #100 by adding comprehensive dev panels for improved developer experience:

- **Left Panel**: Global settings (throttle delay, snapping toggles) and mode controls (draw/edit/helper modes)
- **Right Panel**: Live layer/source monitoring with feature counts, GeoJSON tools, event logger, and debug info
- **Collapsible Sections**: All layer groups are collapsible to reduce visual clutter
- **Keyboard Shortcuts**: Ctrl+1/Cmd+1 and Ctrl+2/Cmd+2 to toggle panels
- **Persistence**: Panel state saved to localStorage

## Test Plan
- Toggle left and right panels with keyboard shortcuts and collapse buttons
- Verify layer groups collapse/expand and toggle icons rotate correctly
- Load test shapes and verify feature counts update in real time
- Test GeoJSON import/export and copy-to-clipboard functionality
- Verify event logger captures all geoman events and filters work
- Test panel persistence across page reloads