### PR TITLE
fix: restore test stability after dev panels were added

### DIFF
--- a/src/dev/index.maplibre.test.ts
+++ b/src/dev/index.maplibre.test.ts
@@ -11,6 +11,12 @@ log.setLevel('debug');
 // Expose utilities for testing
 window.geomanUtils = geojsonUtils;
 
+// Hide dev panels in test mode - they take up space and interfere with tests
+const leftPanel = document.getElementById('dev-left-panel');
+const rightPanel = document.getElementById('dev-right-panel');
+if (leftPanel) leftPanel.style.display = 'none';
+if (rightPanel) rightPanel.style.display = 'none';
+
 const emptyStyle: ml.StyleSpecification = {
   version: 8,
   glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',

--- a/tests/events/event-ordering.spec.ts
+++ b/tests/events/event-ordering.spec.ts
@@ -457,7 +457,11 @@ test.describe('awaitDataUpdatesOnEvents Setting', () => {
 
     // Draw a rectangle
     await page.click('#id_draw_rectangle');
+    await page.waitForTimeout(100); // Wait for draw mode to activate
+    await page.mouse.move(centerX - 50, centerY - 50);
     await page.mouse.click(centerX - 50, centerY - 50);
+    await page.waitForTimeout(100);
+    await page.mouse.move(centerX + 50, centerY + 50);
     await page.mouse.click(centerX + 50, centerY + 50);
 
     // Wait for event
@@ -528,7 +532,11 @@ test.describe('awaitDataUpdatesOnEvents Setting', () => {
 
     // Draw a rectangle
     await page.click('#id_draw_rectangle');
+    await page.waitForTimeout(100); // Wait for draw mode to activate
+    await page.mouse.move(centerX - 50, centerY - 50);
     await page.mouse.click(centerX - 50, centerY - 50);
+    await page.waitForTimeout(100);
+    await page.mouse.move(centerX + 50, centerY + 50);
     await page.mouse.click(centerX + 50, centerY + 50);
 
     // Wait for event

--- a/tests/utils/features.ts
+++ b/tests/utils/features.ts
@@ -237,7 +237,15 @@ export const getFeatureMarkersData = async ({
 
         if (position) {
           result.position = position as LngLatTuple;
-          result.point = geoman.mapAdapter.project(position as LngLatTuple);
+          // Get point relative to map container
+          const containerPoint = geoman.mapAdapter.project(position as LngLatTuple);
+          // Convert to viewport coordinates by adding container offset
+          const container = geoman.mapAdapter.getContainer();
+          const rect = container.getBoundingClientRect();
+          result.point = [
+            Math.round(containerPoint[0] + rect.left),
+            Math.round(containerPoint[1] + rect.top),
+          ];
           markers.push(result);
         }
       });

--- a/tests/utils/shapes.ts
+++ b/tests/utils/shapes.ts
@@ -17,8 +17,14 @@ export const getScreenCoordinatesByLngLat = async ({
         return null;
       }
 
+      // Get point relative to map container
       const point = geoman.mapAdapter.project(context.position);
-      return [Math.round(point[0]), Math.round(point[1])];
+
+      // Get map container's offset from viewport to convert to viewport coordinates
+      const container = geoman.mapAdapter.getContainer();
+      const rect = container.getBoundingClientRect();
+
+      return [Math.round(point[0] + rect.left), Math.round(point[1] + rect.top)];
     },
     { position },
   );


### PR DESCRIPTION
## Summary
- Hide dev panels in test mode to ensure map takes full viewport
- Fix coordinate conversion to account for map container offset
- Add proper timing delays in event-ordering tests for draw operations
- Update rotate event test to expect polygon shape for rectangles at rotatestart

## Test plan
- [x] Run `npm run test` locally - 173 tests passing
- [ ] CI tests should pass