### PR TITLE
feat: mark internal APIs with @internal JSDoc tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Mark internal APIs with `@internal` JSDoc tags for clearer public/private API boundary ([#114](https://github.com/geoman-io/maplibre-geoman/pull/114))
+- Rename `updateGeoJsonCustomProperties()` to `updateGeoJsonProperties()` and `deleteGeoJsonCustomProperties()` to `deleteGeoJsonProperties()` for simpler naming ([#114](https://github.com/geoman-io/maplibre-geoman/pull/114))
+- `updateGeoJsonGeometry()` is now part of the public API for programmatic feature manipulation ([#114](https://github.com/geoman-io/maplibre-geoman/pull/114))
+
+### Removed
+
+- Remove unused `setGeoJsonCustomProperties()` method ([#114](https://github.com/geoman-io/maplibre-geoman/pull/114))
+
+### Other
+
 - Updated maplibre-gl to 5.15.0
 - Expanded peerDependencies to support maplibre-gl >=5.14.0
 - Increased Playwright CI workers from 1 to 4 for faster test runs

--- a/src/core/features/feature-data.ts
+++ b/src/core/features/feature-data.ts
@@ -229,7 +229,10 @@ export class FeatureData {
     this.markers = new Map();
   }
 
-  /** @internal */
+  /**
+   * Updates the geometry of the feature.
+   * Use this to programmatically move or reshape features.
+   */
   updateGeoJsonGeometry(geometry: BasicGeometry) {
     const featureGeoJson = this.getGeoJson();
     if (!featureGeoJson) {
@@ -260,23 +263,6 @@ export class FeatureData {
     this._geoJson.properties = { ...this._geoJson.properties, ...properties };
     const diff = { update: [this._geoJson] };
 
-    this.gm.features.updateManager.updateSource({
-      diff,
-      sourceName: this.sourceName,
-    });
-  }
-
-  /** @internal */
-  setGeoJsonCustomProperties(properties: Feature['properties']) {
-    if (!this._geoJson) {
-      throw new Error(`Feature not found: "${this.id}"`);
-    }
-
-    const mandatoryProperties = this.parseGmShapeProperties(this._geoJson);
-
-    this._geoJson.properties = { ...properties, ...mandatoryProperties };
-
-    const diff = { update: [this._geoJson] };
     this.gm.features.updateManager.updateSource({
       diff,
       sourceName: this.sourceName,

--- a/src/core/features/feature-data.ts
+++ b/src/core/features/feature-data.ts
@@ -321,6 +321,7 @@ export class FeatureData {
     });
   }
 
+  /** @internal */
   convertToPolygon(): boolean {
     if (this.isConvertableToPolygon()) {
       this.shape = 'polygon';
@@ -334,6 +335,7 @@ export class FeatureData {
     return false;
   }
 
+  /** @internal */
   isConvertableToPolygon(): boolean {
     return toPolygonAllowedShapes.includes(this.shape);
   }

--- a/src/core/features/feature-data.ts
+++ b/src/core/features/feature-data.ts
@@ -28,6 +28,7 @@ import type { Feature } from 'geojson';
 import { cloneDeep } from 'lodash-es';
 import log from 'loglevel';
 
+/** @internal */
 export const toPolygonAllowedShapes: Array<FeatureData['shape']> = [
   'circle',
   'ellipse',
@@ -35,11 +36,16 @@ export const toPolygonAllowedShapes: Array<FeatureData['shape']> = [
 ];
 
 export class FeatureData {
+  /** @internal */
   gm: Geoman;
   id: FeatureId = 'no-id';
+  /** @internal */
   parent: FeatureData | null = null;
+  /** @internal */
   markers: Map<MarkerId, MarkerData>;
+  /** @internal */
   source: BaseSource;
+  /** @internal */
   _geoJson: GeoJsonShapeFeature | null = null;
 
   constructor(parameters: FeatureDataParameters) {
@@ -83,6 +89,7 @@ export class FeatureData {
     throw new Error(`Wrong shape type: "${value}"`);
   }
 
+  /** @internal */
   set shape(shape: FeatureShape) {
     this.setShapeProperty('shape', shape);
   }
@@ -110,6 +117,7 @@ export class FeatureData {
     return undefined;
   }
 
+  /** @internal */
   setShapeProperty<T extends keyof FeatureShapeProperties>(
     name: T,
     value: ShapeGeoJsonProperties[`${typeof FEATURE_PROPERTY_PREFIX}${T}`],
@@ -122,6 +130,7 @@ export class FeatureData {
     this.updateGeoJsonProperties(this._geoJson.properties);
   }
 
+  /** @internal */
   deleteShapeProperty<T extends keyof FeatureShapeProperties>(name: T) {
     if (!this._geoJson) {
       log.error(`FeatureData.deleteShapeProperty(): geojson is not set`);
@@ -131,6 +140,7 @@ export class FeatureData {
     this.updateGeoJsonProperties(this._geoJson.properties);
   }
 
+  /** @internal */
   parseGmShapeProperties(geoJson: GeoJsonShapeFeature): PrefixedFeatureShapeProperties {
     const shape =
       this.getShapeProperty('shape', geoJson) || this.gm.features.getFeatureShapeByGeoJson(geoJson);
@@ -156,6 +166,7 @@ export class FeatureData {
     );
   }
 
+  /** @internal */
   parseExtraProperties(geoJson: GeoJsonShapeFeature) {
     const extraProperties = cloneDeep(geoJson.properties) || {};
     typedKeys(propertyValidators).forEach((name) => {
@@ -173,6 +184,7 @@ export class FeatureData {
     }
   }
 
+  /** @internal */
   addGeoJson(geoJson: GeoJsonShapeFeature) {
     this._geoJson = {
       ...geoJson,
@@ -193,6 +205,7 @@ export class FeatureData {
     });
   }
 
+  /** @internal */
   removeGeoJson() {
     if (!this._geoJson) {
       throw new Error(`Feature not found: "${this.id}"`);
@@ -204,6 +217,7 @@ export class FeatureData {
     });
   }
 
+  /** @internal */
   removeMarkers() {
     this.markers.forEach((markerData) => {
       if (markerData.instance instanceof BaseDomMarker) {
@@ -215,6 +229,7 @@ export class FeatureData {
     this.markers = new Map();
   }
 
+  /** @internal */
   updateGeoJsonGeometry(geometry: BasicGeometry) {
     const featureGeoJson = this.getGeoJson();
     if (!featureGeoJson) {
@@ -232,6 +247,7 @@ export class FeatureData {
     });
   }
 
+  /** @internal */
   updateGeoJsonProperties(properties: Partial<ShapeGeoJsonProperties>) {
     if (!this._geoJson) {
       throw new Error(`Feature not found: "${this.id}"`);
@@ -246,6 +262,7 @@ export class FeatureData {
     });
   }
 
+  /** @internal */
   setGeoJsonCustomProperties(properties: Feature['properties']) {
     if (!this._geoJson) {
       throw new Error(`Feature not found: "${this.id}"`);
@@ -323,16 +340,7 @@ export class FeatureData {
     return toPolygonAllowedShapes.includes(this.shape);
   }
 
-  // changeSource({ sourceName, atomic }: { sourceName: FeatureSourceName; atomic: boolean }) {
-  //   if (atomic) {
-  //     this.gm.features.updateManager.withAtomicSourcesUpdate(() =>
-  //       this.actualChangeSource({ sourceName, atomic }),
-  //     );
-  //   } else {
-  //     this.actualChangeSource({ sourceName, atomic });
-  //   }
-  // }
-
+  /** @internal */
   changeSource({ sourceName, atomic }: { sourceName: FeatureSourceName; atomic: boolean }) {
     if (this.source.id === sourceName) {
       log.error(
@@ -364,6 +372,7 @@ export class FeatureData {
     });
   }
 
+  /** @internal */
   fireFeatureUpdatedEvent({ mode }: { mode: EditModeName }) {
     const payload: GmEditFeatureUpdatedEvent = {
       name: `${GM_SYSTEM_PREFIX}:edit:feature_updated`,
@@ -379,6 +388,7 @@ export class FeatureData {
     this.gm.events.fire(`${GM_SYSTEM_PREFIX}:edit`, payload);
   }
 
+  /** @internal */
   delete() {
     this.removeGeoJson();
     this.removeMarkers();

--- a/src/core/features/feature-data.ts
+++ b/src/core/features/feature-data.ts
@@ -127,7 +127,7 @@ export class FeatureData {
       return;
     }
     this._geoJson.properties[`${FEATURE_PROPERTY_PREFIX}${name}`] = value;
-    this.updateGeoJsonProperties(this._geoJson.properties);
+    this.updateGeoJsonInternalProperties(this._geoJson.properties);
   }
 
   /** @internal */
@@ -137,7 +137,7 @@ export class FeatureData {
       return;
     }
     delete this._geoJson.properties[`${FEATURE_PROPERTY_PREFIX}${name}`];
-    this.updateGeoJsonProperties(this._geoJson.properties);
+    this.updateGeoJsonInternalProperties(this._geoJson.properties);
   }
 
   /** @internal */
@@ -247,8 +247,12 @@ export class FeatureData {
     });
   }
 
-  /** @internal */
-  updateGeoJsonProperties(properties: Partial<ShapeGeoJsonProperties>) {
+  /**
+   * Updates the raw GeoJSON properties including internal shape properties.
+   * Used internally by setShapeProperty and deleteShapeProperty.
+   * @internal
+   */
+  updateGeoJsonInternalProperties(properties: Partial<ShapeGeoJsonProperties>) {
     if (!this._geoJson) {
       throw new Error(`Feature not found: "${this.id}"`);
     }
@@ -279,7 +283,11 @@ export class FeatureData {
     });
   }
 
-  updateGeoJsonCustomProperties(properties: Feature['properties']) {
+  /**
+   * Updates user-defined properties on the feature while preserving internal shape properties.
+   * Use this to add or modify custom metadata on features.
+   */
+  updateGeoJsonProperties(properties: Feature['properties']) {
     if (!this._geoJson) {
       throw new Error(`Feature not found: "${this.id}"`);
     }
@@ -299,7 +307,11 @@ export class FeatureData {
     });
   }
 
-  deleteGeoJsonCustomProperties(fieldNames: Array<string>) {
+  /**
+   * Deletes user-defined properties from the feature.
+   * Internal shape properties (prefixed with __gm_) cannot be deleted.
+   */
+  deleteGeoJsonProperties(fieldNames: Array<string>) {
     if (!this._geoJson) {
       throw new Error(`Feature not found: "${this.id}"`);
     }

--- a/src/core/features/index.ts
+++ b/src/core/features/index.ts
@@ -42,15 +42,23 @@ import { cloneDeep } from 'lodash-es';
 import log from 'loglevel';
 
 export class Features {
+  /** @internal */
   gm: Geoman;
 
+  /** @internal */
   featureCounter: number = 0;
+  /** @internal */
   featureStore: FeatureStore = new Map<FeatureId, FeatureData>();
+  /** @internal */
   featureStoreAllowedSources: Array<FeatureSourceName> = [SOURCES.main, SOURCES.temporary];
 
+  /** @internal */
   sources: SourcesStorage;
+  /** @internal */
   defaultSourceName: FeatureSourceName = SOURCES.main;
+  /** @internal */
   updateManager: SourceUpdateManager;
+  /** @internal */
   layers: Array<BaseLayer>;
 
   constructor(gm: Geoman) {
@@ -68,10 +76,12 @@ export class Features {
     return this.filteredForEach((featureData) => !featureData.temporary);
   }
 
+  /** @internal */
   get tmpForEach() {
     return this.filteredForEach((featureData) => featureData.temporary);
   }
 
+  /** @internal */
   init() {
     if (Object.values(this.sources).some((source) => source !== null)) {
       log.warn('features.init(): features are already initialized');
@@ -94,6 +104,7 @@ export class Features {
   /**
    * Hydrates the feature store from existing sources and syncs the ID counter.
    * This is called during init to restore state when remounting on preserved sources.
+   * @internal
    */
   hydrateFromExistingSources() {
     let maxCounter = 0;
@@ -145,6 +156,7 @@ export class Features {
     }
   }
 
+  /** @internal */
   getNewFeatureId(shapeGeoJson: GeoJsonShapeFeature): FeatureId {
     this.featureCounter += 1;
 
@@ -162,6 +174,7 @@ export class Features {
     return newFeatureId;
   }
 
+  /** @internal */
   filteredForEach(filterFn: (featureData: FeatureData) => boolean) {
     return (callbackfn: ForEachFeatureDataCallbackFn): void => {
       this.featureStore.forEach((featureData, featureId, featureStore) => {
@@ -186,6 +199,7 @@ export class Features {
     return null;
   }
 
+  /** @internal */
   add(featureData: FeatureData) {
     if (this.featureStore.has(featureData.id)) {
       log.error(`features.add: feature with the id "${featureData.id}" already exists`);
@@ -197,10 +211,12 @@ export class Features {
     }
   }
 
+  /** @internal */
   setDefaultSourceName(sourceName: FeatureSourceName) {
     this.defaultSourceName = sourceName;
   }
 
+  /** @internal */
   createSource(sourceName: FeatureSourceName) {
     const source = this.gm.mapAdapter.addSource(sourceName, {
       type: 'FeatureCollection',
@@ -232,6 +248,7 @@ export class Features {
     }
   }
 
+  /** @internal */
   deleteAll() {
     this.featureStore.forEach((featureData) => {
       featureData.delete();
@@ -239,6 +256,7 @@ export class Features {
     this.featureStore.clear();
   }
 
+  /** @internal */
   getFeatureByMouseEvent({
     event,
     sourceNames,
@@ -258,6 +276,7 @@ export class Features {
     return features.length ? features[0] : null;
   }
 
+  /** @internal */
   getFeaturesByGeoJsonBounds({
     geoJson,
     sourceNames,
@@ -271,6 +290,7 @@ export class Features {
     return this.getFeaturesByScreenBounds({ bounds: polygonScreenBounds, sourceNames });
   }
 
+  /** @internal */
   getFeaturesByScreenBounds({
     bounds,
     sourceNames,
@@ -284,6 +304,7 @@ export class Features {
     });
   }
 
+  /** @internal */
   createFeature({
     featureId,
     shapeGeoJson,
@@ -372,6 +393,7 @@ export class Features {
     return result;
   }
 
+  /** @internal */
   importGeoJsonFeature(shapeGeoJson: GeoJsonImportFeature): FeatureData | null {
     // add an externally created GeoJSON
     const sourceName: FeatureSourceName = this.defaultSourceName;
@@ -390,6 +412,7 @@ export class Features {
     });
   }
 
+  /** @internal */
   getAll(): FeatureCollection {
     return this.exportGeoJson();
   }
@@ -410,6 +433,7 @@ export class Features {
     });
   }
 
+  /** @internal */
   asGeoJsonFeatureCollection({
     shapeTypes,
     sourceNames,
@@ -461,6 +485,7 @@ export class Features {
     return resultFeatureCollection;
   }
 
+  /** @internal */
   convertSourceToGm(inputSource: BaseSource): Array<FeatureData> {
     // adds an externally created source to the features store
     // the method converts the source/layers to internal format
@@ -486,6 +511,7 @@ export class Features {
     return features;
   }
 
+  /** @internal */
   addGeoJsonFeature({
     shapeGeoJson,
     sourceName,
@@ -527,6 +553,7 @@ export class Features {
     });
   }
 
+  /** @internal */
   createLayers(): Array<BaseLayer> {
     const layers: Array<BaseLayer> = [];
 
@@ -550,6 +577,7 @@ export class Features {
     return layers;
   }
 
+  /** @internal */
   createGenericLayer({
     sourceName,
     shapeNames,
@@ -574,6 +602,7 @@ export class Features {
     return this.gm.mapAdapter.addLayer(layerOptions);
   }
 
+  /** @internal */
   getGenericLayerName({
     sourceName,
     shapeNames,
@@ -600,6 +629,7 @@ export class Features {
     return null;
   }
 
+  /** @internal */
   getFeatureShapeByGeoJson(shapeGeoJson: Feature): ShapeName | null {
     const SHAPE_MAP: { [key in Geometry['type']]?: ShapeName } = {
       Point: 'marker',
@@ -617,6 +647,7 @@ export class Features {
     return SHAPE_MAP[shapeGeoJson.geometry.type] || null;
   }
 
+  /** @internal */
   createMarkerFeature({
     parentFeature,
     coordinate,
@@ -644,6 +675,7 @@ export class Features {
     });
   }
 
+  /** @internal */
   updateMarkerFeaturePosition(markerFeatureData: FeatureData, coordinates: LngLatTuple) {
     markerFeatureData.updateGeoJsonGeometry({
       type: 'Point',
@@ -651,6 +683,7 @@ export class Features {
     });
   }
 
+  /** @internal */
   fireFeatureCreatedEvent(featureData: FeatureData) {
     if (includesWithType(featureData.shape, SHAPE_NAMES)) {
       const payload: GmDrawFeatureCreatedEvent = {


### PR DESCRIPTION
## Summary
- Add `@internal` JSDoc tags to internal implementation details in the features module
- Clarifies the public vs private API boundary for documentation tools and IDEs
- Simplify public method names by removing "Custom" prefix
- Remove unused `setGeoJsonCustomProperties` method (dead code)
- No runtime changes, only documentation annotations and method renaming

### Public API (FeatureData)
- `id`, `shape` (getter), `temporary`, `sourceName`
- `getGeoJson()`, `getShapeProperty()`
- `updateGeoJsonGeometry()` - programmatically move or reshape features
- `updateGeoJsonProperties()` - update user-defined properties (renamed from `updateGeoJsonCustomProperties`)
- `deleteGeoJsonProperties()` - delete user-defined properties (renamed from `deleteGeoJsonCustomProperties`)

### Public API (Features via `gm.features`)
- `forEach`, `has()`, `get()`, `delete()`
- `importGeoJson()`, `exportGeoJson()`

### Internal changes
- Renamed internal `updateGeoJsonProperties` to `updateGeoJsonInternalProperties` to avoid naming collision
- Removed unused `setGeoJsonCustomProperties` method
- Added `@internal` tags to `convertToPolygon()` and `isConvertableToPolygon()`

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify no runtime behavior changes