### PR TITLE
feat: add overwrite option for importGeoJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `overwrite` option for `importGeoJson()` to replace existing features with the same ID ([#113](https://github.com/geoman-io/maplibre-geoman/issues/113))
+  - When `overwrite: true`, existing features with matching IDs are deleted before importing the new feature
+  - Import result now includes `stats.overwritten` count to track how many features were replaced
+
+### Changed
+
+- **BREAKING**: `importGeoJson()` signature changed from `importGeoJson(geoJson, idPropertyName?)` to `importGeoJson(geoJson, options?)`
+  - Previously: `geoman.features.importGeoJson(geoJson, 'customIdProperty')`
+  - Now: `geoman.features.importGeoJson(geoJson, { idPropertyName: 'customIdProperty' })`
+  - This allows for additional options like `overwrite`
+
 ### Fixed
 
 - Dev panel "Clear All Shapes" now properly clears the internal featureStore ([#112](https://github.com/geoman-io/maplibre-geoman/pull/112))

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -50,3 +50,10 @@ export type PrefixedFeatureShapeProperties = WithPrefixedKeys<
   FeatureShapeProperties,
   typeof FEATURE_PROPERTY_PREFIX
 >;
+
+export type ImportGeoJsonOptions = {
+  /** Property name to use as feature ID (e.g., 'id', 'customId') */
+  idPropertyName?: string;
+  /** If true, existing features with the same ID will be replaced */
+  overwrite?: boolean;
+};


### PR DESCRIPTION
## Summary

- Add `overwrite` option for `importGeoJson()` to replace existing features with the same ID
- When `overwrite: true`, existing features with matching IDs are deleted before importing the new feature
- Import result now includes `stats.overwritten` count to track how many features were replaced

## Breaking Change

`importGeoJson()` signature changed from `importGeoJson(geoJson, idPropertyName?)` to `importGeoJson(geoJson, options?)`.

**Migration:**
```typescript
// Before
geoman.features.importGeoJson(geoJson, 'customIdProperty');

// After  
geoman.features.importGeoJson(geoJson, { idPropertyName: 'customIdProperty' });

// New overwrite feature
geoman.features.importGeoJson(geoJson, { overwrite: true });

// Both options together
geoman.features.importGeoJson(geoJson, { 
  idPropertyName: 'customIdProperty',
  overwrite: true 
});
```

## Test plan

- [x] Added tests for overwrite with single feature
- [x] Added tests for overwrite=false (default behavior preserved)
- [x] Added tests for batch import with overwrite
- [x] Added tests for idPropertyName option (new API)
- [x] Added tests for idPropertyName + overwrite together
- [x] TypeScript compiles successfully
- [x] Build completes successfully

Closes #113