### PR TITLE
fix: hide empty toolbar groups to prevent layout issues

### DIFF
--- a/src/core/controls/components/control-menu.svelte
+++ b/src/core/controls/components/control-menu.svelte
@@ -7,14 +7,12 @@
   const gm: Geoman = getContext('gm');
   const { control }: { control: GenericSystemControl } = $props();
 
-  const actionType = control.type;
-  const modeName = control.targetMode;
+  const actionType = $derived(control.type);
+  const modeName = $derived(control.targetMode);
 
-  let actionInstance: ActionInstance | null = $state(null);
-
-  if (actionType && modeName) {
-    actionInstance = gm.actionInstances[`${actionType}__${modeName}`] || null;
-  }
+  const actionInstance: ActionInstance | null = $derived(
+    actionType && modeName ? gm.actionInstances[`${actionType}__${modeName}`] || null : null
+  );
 </script>
 
 {#if actionInstance}

--- a/src/core/controls/components/gm-controls.svelte
+++ b/src/core/controls/components/gm-controls.svelte
@@ -19,6 +19,13 @@
     return controlSection?.[mode as ModeName] || null;
   };
 
+  const hasVisibleControls = (groupKey: string, groupControls: Record<string, unknown>) => {
+    return Object.entries(groupControls).some(([controlKey, controlOptions]) => {
+      const control = getControl(groupKey, controlKey);
+      return control && controlOptions && (controlOptions as { uiEnabled?: boolean }).uiEnabled;
+    });
+  };
+
   const toggleExpanded = () => {
     expanded = !expanded;
   };
@@ -40,22 +47,20 @@
   {#if expanded}
     <div in:slide={{ duration: 180 }} out:slide={{ duration: 140 }}>
       {#each Object.entries($controlsStore.options) as [groupKey, groupControls] (groupKey)}
-        <div class={`${controlsStyles.controlGroupClass} group-${groupKey}`}>
-          {#each Object.entries(groupControls) as [controlKey, controlOptions] (controlKey)}
-            {@const control = getControl(groupKey, controlKey)}
-            {#if control}
-              <ActionControl control={control} controlOptions={controlOptions} />
-            {/if}
-          {/each}
-        </div>
+        {#if hasVisibleControls(groupKey, groupControls)}
+          <div class={`${controlsStyles.controlGroupClass} group-${groupKey}`}>
+            {#each Object.entries(groupControls) as [controlKey, controlOptions] (controlKey)}
+              {@const control = getControl(groupKey, controlKey)}
+              {#if control}
+                <ActionControl control={control} controlOptions={controlOptions} />
+              {/if}
+            {/each}
+          </div>
+        {/if}
       {/each}
     </div>
   {/if}
 </div>
 
 <style>
-  .gm-reactive-controls {
-    display: flex;
-    flex-direction: column;
-  }
 </style>

--- a/src/styles/map/maplibre.css
+++ b/src/styles/map/maplibre.css
@@ -1,4 +1,10 @@
 /* Controls */
+.geoman-controls,
+.geoman-controls .gm-reactive-controls,
+.geoman-controls .gm-reactive-controls > div {
+  display: contents;
+}
+
 .maplibregl-ctrl-group button.gm-control-button {
   color: #2371a0;
   padding: 6px;

--- a/tests/draw/layer-styles.spec.ts
+++ b/tests/draw/layer-styles.spec.ts
@@ -1,0 +1,134 @@
+import test, { expect } from '@playwright/test';
+import { getWindowDimensions, waitForGeoman } from '@tests/utils/basic.ts';
+
+test.describe('Draw Mode - Layer Styles', () => {
+  test('marker draw preview should respect gm_temporary icon-opacity', async ({ page }) => {
+    await page.goto('/');
+    await waitForGeoman(page);
+
+    // Destroy and recreate Geoman with custom temporary marker opacity
+    await page.evaluate(() => {
+      const mapInstance = window.mapInstance;
+      window.geoman.destroy({ removeSources: true });
+
+      // Create new Geoman with custom temporary marker opacity
+      const GeomanClass = window.GeomanClass;
+      const gm = new GeomanClass(mapInstance, {
+        layerStyles: {
+          marker: {
+            gm_temporary: [
+              {
+                type: 'symbol',
+                layout: {
+                  'icon-image': 'default-marker',
+                  'icon-size': 0.18,
+                  'icon-allow-overlap': true,
+                  'icon-anchor': 'bottom',
+                },
+                paint: {
+                  'icon-opacity': 0.5,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      window.geoman = gm;
+    });
+
+    await waitForGeoman(page);
+
+    // Get window center
+    const { width, height } = await getWindowDimensions(page);
+    const centerX = width / 2;
+    const centerY = height / 2;
+
+    // Enable marker draw mode
+    await page.evaluate(() => {
+      window.geoman.enableMode('draw', 'marker');
+    });
+
+    // Move mouse to trigger the marker pointer to appear
+    await page.mouse.move(centerX, centerY);
+    await page.waitForTimeout(100);
+
+    // Check the marker-wrapper element has the correct opacity
+    const markerOpacity = await page.evaluate(() => {
+      const markerWrapper = document.querySelector('.marker-wrapper');
+      if (!markerWrapper) return null;
+
+      const svg = markerWrapper.querySelector('svg');
+      if (!svg) return null;
+
+      return svg.style.opacity;
+    });
+
+    expect(markerOpacity).toBe('0.5');
+  });
+
+  test('marker draw preview should respect gm_temporary icon-size', async ({ page }) => {
+    await page.goto('/');
+    await waitForGeoman(page);
+
+    // Destroy and recreate Geoman with custom temporary marker size
+    await page.evaluate(() => {
+      const mapInstance = window.mapInstance;
+      window.geoman.destroy({ removeSources: true });
+
+      // Create new Geoman with larger icon-size (0.36 = 2x default of 0.18)
+      const GeomanClass = window.GeomanClass;
+      const gm = new GeomanClass(mapInstance, {
+        layerStyles: {
+          marker: {
+            gm_temporary: [
+              {
+                type: 'symbol',
+                layout: {
+                  'icon-image': 'default-marker',
+                  'icon-size': 0.36, // 2x the default 0.18
+                  'icon-allow-overlap': true,
+                  'icon-anchor': 'bottom',
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      window.geoman = gm;
+    });
+
+    await waitForGeoman(page);
+
+    // Get window center
+    const { width, height } = await getWindowDimensions(page);
+    const centerX = width / 2;
+    const centerY = height / 2;
+
+    // Enable marker draw mode
+    await page.evaluate(() => {
+      window.geoman.enableMode('draw', 'marker');
+    });
+
+    // Move mouse to trigger the marker pointer to appear
+    await page.mouse.move(centerX, centerY);
+    await page.waitForTimeout(100);
+
+    // Check the marker-wrapper element has the correct size (72px = 36px * 2)
+    const markerSize = await page.evaluate(() => {
+      const markerWrapper = document.querySelector('.marker-wrapper');
+      if (!markerWrapper) return null;
+
+      const svg = markerWrapper.querySelector('svg');
+      if (!svg) return null;
+
+      return {
+        width: svg.style.width,
+        height: svg.style.height,
+      };
+    });
+
+    expect(markerSize).toEqual({ width: '72px', height: '72px' });
+  });
+});


### PR DESCRIPTION
## Summary
- Only render control group containers when they have visible controls
- Fixes toolbar positioning issues when used with React Map GL
- Fixes empty divs pushing other MapLibre controls out of alignment
- Fixes Svelte 5 reactivity warning in control-menu.svelte

## Test plan
- [ ] Verify toolbar groups without enabled controls are not rendered in DOM
- [ ] Test with React Map GL to confirm proper stacking with other controls
- [ ] Confirm no Svelte warnings during build

Closes #107