### PR TITLE
chore: run prettier formatter on codebase

### DIFF
--- a/src/core/features/source-update-manager.ts
+++ b/src/core/features/source-update-manager.ts
@@ -148,7 +148,10 @@ export class SourceUpdateManager {
     // This handles the case where MapLibre's _updateWorkerData returns early due to
     // _isUpdatingWorker being true, and the actual data gets processed via the
     // recursive call in the finally block.
-    while (this.updateStorage[sourceName]?.length || this.pendingUpdatePromises[sourceName]?.length) {
+    while (
+      this.updateStorage[sourceName]?.length ||
+      this.pendingUpdatePromises[sourceName]?.length
+    ) {
       // Flush any queued updates that haven't been processed yet
       if (this.updateStorage[sourceName]?.length) {
         const combinedDiff = this.getCombinedDiff(sourceName);

--- a/src/dev/index.maplibre.dev.ts
+++ b/src/dev/index.maplibre.dev.ts
@@ -1,10 +1,6 @@
 import mapLibreStyle from '@/dev/maplibre-style.ts';
 import { layerStyles } from '@/dev/styles/layer-styles.ts';
-import {
-  Geoman,
-  type GmOptionsData,
-  type MapInstanceWithGeoman,
-} from '@/main.ts';
+import { Geoman, type GmOptionsData, type MapInstanceWithGeoman } from '@/main.ts';
 import log from 'loglevel';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import ml from 'maplibre-gl';

--- a/src/dev/styles/style.css
+++ b/src/dev/styles/style.css
@@ -23,7 +23,9 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: flex-basis 0.2s ease, opacity 0.2s ease;
+  transition:
+    flex-basis 0.2s ease,
+    opacity 0.2s ease;
 }
 
 #dev-left-panel {
@@ -167,7 +169,7 @@ body {
 
 .dev-toggle-slider:before {
   position: absolute;
-  content: "";
+  content: '';
   height: 14px;
   width: 14px;
   left: 3px;
@@ -178,7 +180,7 @@ body {
 }
 
 .dev-toggle input:checked + .dev-toggle-slider {
-  background-color: #4CAF50;
+  background-color: #4caf50;
 }
 
 .dev-toggle input:checked + .dev-toggle-slider:before {
@@ -207,8 +209,8 @@ body {
 }
 
 .dev-btn.primary {
-  background: #4CAF50;
-  border-color: #4CAF50;
+  background: #4caf50;
+  border-color: #4caf50;
   color: white;
 }
 
@@ -262,8 +264,8 @@ body {
 
 .dev-mode-btn.active {
   background: #e3f2fd;
-  border-color: #2196F3;
-  color: #1976D2;
+  border-color: #2196f3;
+  color: #1976d2;
 }
 
 .dev-mode-btn.disabled {
@@ -282,7 +284,7 @@ body {
 
 .dev-input:focus {
   outline: none;
-  border-color: #2196F3;
+  border-color: #2196f3;
 }
 
 /* Textarea */
@@ -300,7 +302,7 @@ body {
 
 .dev-textarea:focus {
   outline: none;
-  border-color: #2196F3;
+  border-color: #2196f3;
 }
 
 /* Event Log */
@@ -394,7 +396,7 @@ body {
 
 .dev-filter-btn.active {
   background: #e3f2fd;
-  border-color: #2196F3;
+  border-color: #2196f3;
 }
 
 /* Keyboard shortcuts hint */

--- a/src/modes/draw/marker.ts
+++ b/src/modes/draw/marker.ts
@@ -99,7 +99,8 @@ export class DrawMarker extends BaseDraw {
     // Calculate pixel size based on icon-size (base size is 36px at icon-size: 0.18)
     const baseSize = 36;
     const defaultIconSize = 0.18;
-    const pixelSize = iconSize !== undefined ? Math.round(baseSize * (iconSize / defaultIconSize)) : baseSize;
+    const pixelSize =
+      iconSize !== undefined ? Math.round(baseSize * (iconSize / defaultIconSize)) : baseSize;
     const sizeStr = `${pixelSize}px`;
 
     const iconElement = this.gm.createSvgMarkerElement('default', {

--- a/tests/edit/advanced.spec.ts
+++ b/tests/edit/advanced.spec.ts
@@ -43,7 +43,7 @@ test.describe('Edit Mode - Advanced Scenarios', () => {
       await enableMode(page, 'edit', 'drag');
 
       const isEnabled = await page.evaluate(() =>
-        window.geoman.options.isModeEnabled('edit', 'drag')
+        window.geoman.options.isModeEnabled('edit', 'drag'),
       );
 
       expect(isEnabled).toBe(true);
@@ -53,7 +53,7 @@ test.describe('Edit Mode - Advanced Scenarios', () => {
       await enableMode(page, 'edit', 'change');
 
       const isEnabled = await page.evaluate(() =>
-        window.geoman.options.isModeEnabled('edit', 'change')
+        window.geoman.options.isModeEnabled('edit', 'change'),
       );
 
       expect(isEnabled).toBe(true);
@@ -63,7 +63,7 @@ test.describe('Edit Mode - Advanced Scenarios', () => {
       await enableMode(page, 'edit', 'rotate');
 
       const isEnabled = await page.evaluate(() =>
-        window.geoman.options.isModeEnabled('edit', 'rotate')
+        window.geoman.options.isModeEnabled('edit', 'rotate'),
       );
 
       expect(isEnabled).toBe(true);
@@ -133,7 +133,10 @@ test.describe('Edit Mode - Advanced Scenarios', () => {
         expect(initialLngLat).not.toBeNull();
 
         if (initialLngLat) {
-          const initialPoint = await getScreenCoordinatesByLngLat({ page, position: initialLngLat });
+          const initialPoint = await getScreenCoordinatesByLngLat({
+            page,
+            position: initialLngLat,
+          });
           expect(initialPoint).not.toBeNull();
 
           if (initialPoint) {
@@ -169,7 +172,10 @@ test.describe('Edit Mode - Advanced Scenarios', () => {
         expect(initialLngLat).not.toBeNull();
 
         if (initialLngLat) {
-          const initialPoint = await getScreenCoordinatesByLngLat({ page, position: initialLngLat });
+          const initialPoint = await getScreenCoordinatesByLngLat({
+            page,
+            position: initialLngLat,
+          });
           expect(initialPoint).not.toBeNull();
 
           if (initialPoint) {
@@ -268,7 +274,9 @@ test.describe('Edit Mode - Advanced Scenarios', () => {
   test.describe('Edit mode switching', () => {
     test('should cleanly switch from drag to change mode', async () => {
       await enableMode(page, 'edit', 'drag');
-      expect(await page.evaluate(() => window.geoman.options.isModeEnabled('edit', 'drag'))).toBe(true);
+      expect(await page.evaluate(() => window.geoman.options.isModeEnabled('edit', 'drag'))).toBe(
+        true,
+      );
 
       await disableMode(page, 'edit', 'drag');
       await enableMode(page, 'edit', 'change');

--- a/tests/events/event-ordering.spec.ts
+++ b/tests/events/event-ordering.spec.ts
@@ -126,10 +126,7 @@ test.describe('Event Ordering', () => {
 
     // Verify dragend was fired last (if it was fired)
     if (dragendIndices.length > 0) {
-      expect(
-        dragendIndices[0],
-        'dragend should be the last event',
-      ).toBe(eventOrder.length - 1);
+      expect(dragendIndices[0], 'dragend should be the last event').toBe(eventOrder.length - 1);
     }
 
     // Verify all drag events are between dragstart and dragend (if all events were captured)
@@ -234,10 +231,7 @@ test.describe('Event Ordering', () => {
       'Both dragstart events MUST be captured - issue #84 if this fails',
     ).toBe(2);
 
-    expect(
-      dragendEvents.length,
-      'Both dragend events should be captured',
-    ).toBe(2);
+    expect(dragendEvents.length, 'Both dragend events should be captured').toBe(2);
 
     // Verify first drag cycle completes before second starts
     const firstDragendIndex = eventOrder.findIndex((e: string) => e === 'dragend_1');
@@ -420,7 +414,6 @@ test.describe('Event Ordering', () => {
     // (they fire alongside converted events due to the queuing mechanism)
     expect(systemEventIndices.length).toBeGreaterThan(0);
   });
-
 });
 
 test.describe('awaitDataUpdatesOnEvents Setting', () => {
@@ -459,7 +452,9 @@ test.describe('awaitDataUpdatesOnEvents Setting', () => {
         window.geoman.mapAdapter.once('gm:create', ((event: any) => {
           const featureId = event.feature.id;
           const sourceGeoJson = event.feature.source.getGeoJson();
-          const featureInSource = sourceGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
+          const featureInSource = sourceGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
 
           window.customData.rawEventResults![context.resultId] = {
             featureId,
@@ -536,7 +531,9 @@ test.describe('awaitDataUpdatesOnEvents Setting', () => {
           // Use getGmGeoJson() which returns from internal FeatureData state
           // getGeoJson() uses MapLibre's serialize() which may not have the data yet
           const gmGeoJson = event.feature.source.getGmGeoJson();
-          const featureInSource = gmGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
+          const featureInSource = gmGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
 
           window.customData.rawEventResults![context.resultId] = {
             featureId,
@@ -619,10 +616,16 @@ test.describe('awaitDataUpdatesOnEvents Setting', () => {
           const featureId = event.feature.id;
           const sourceGeoJson = event.feature.source.getGeoJson();
           const gmGeoJson = event.feature.source.getGmGeoJson();
-          const featureInSource = sourceGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
-          const featureInGmGeoJson = gmGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
+          const featureInSource = sourceGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
+          const featureInGmGeoJson = gmGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
           const geomanExportGeoJson = window.geoman.features.exportGeoJson();
-          const featureInExport = geomanExportGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
+          const featureInExport = geomanExportGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
 
           window.customData.rawEventResults![context.resultId] = {
             featureId,
@@ -719,10 +722,16 @@ test.describe('awaitDataUpdatesOnEvents Setting', () => {
           const featureId = event.feature.id;
           const sourceGeoJson = event.feature.source.getGeoJson();
           const gmGeoJson = event.feature.source.getGmGeoJson();
-          const featureInSource = sourceGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
-          const featureInGmGeoJson = gmGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
+          const featureInSource = sourceGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
+          const featureInGmGeoJson = gmGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
           const geomanExportGeoJson = window.geoman.features.exportGeoJson();
-          const featureInExport = geomanExportGeoJson.features.some((f: { id?: string | number }) => f.id === featureId);
+          const featureInExport = geomanExportGeoJson.features.some(
+            (f: { id?: string | number }) => f.id === featureId,
+          );
 
           window.customData.rawEventResults![context.resultId] = {
             featureId,

--- a/tests/features/crud.spec.ts
+++ b/tests/features/crud.spec.ts
@@ -373,12 +373,9 @@ test.describe('Feature Management - CRUD Operations', () => {
       const features = await getRenderedFeaturesData({ page, temporary: false });
       expect(features.length).toBeGreaterThan(0);
 
-      const hasResult = await page.evaluate(
-        (featureId) => {
-          return window.geoman.features.has('gm_main', featureId);
-        },
-        features[0].id,
-      );
+      const hasResult = await page.evaluate((featureId) => {
+        return window.geoman.features.has('gm_main', featureId);
+      }, features[0].id);
 
       expect(hasResult).toBe(true);
     });
@@ -400,13 +397,10 @@ test.describe('Feature Management - CRUD Operations', () => {
       const features = await getRenderedFeaturesData({ page, temporary: false });
       expect(features.length).toBeGreaterThan(0);
 
-      const featureData = await page.evaluate(
-        (featureId) => {
-          const fd = window.geoman.features.get('gm_main', featureId);
-          return fd ? { id: fd.id, shape: fd.shape } : null;
-        },
-        features[0].id,
-      );
+      const featureData = await page.evaluate((featureId) => {
+        const fd = window.geoman.features.get('gm_main', featureId);
+        return fd ? { id: fd.id, shape: fd.shape } : null;
+      }, features[0].id);
 
       expect(featureData).not.toBeNull();
       expect(featureData?.id).toBe(features[0].id);
@@ -558,13 +552,10 @@ test.describe('Feature Management - CRUD Operations', () => {
       }
 
       const features = await getRenderedFeaturesData({ page, temporary: false });
-      const featureGeoJson = await page.evaluate(
-        (featureId) => {
-          const fd = window.geoman.features.get('gm_main', featureId);
-          return fd?.getGeoJson() || null;
-        },
-        features[0].id,
-      );
+      const featureGeoJson = await page.evaluate((featureId) => {
+        const fd = window.geoman.features.get('gm_main', featureId);
+        return fd?.getGeoJson() || null;
+      }, features[0].id);
 
       expect(featureGeoJson).not.toBeNull();
       expect(featureGeoJson?.type).toBe('Feature');

--- a/tests/helpers/shape-markers.spec.ts
+++ b/tests/helpers/shape-markers.spec.ts
@@ -85,10 +85,9 @@ test.describe('Shape Markers Helper', () => {
           allowedTypes: ['edge'],
         });
 
-        expect(
-          markers.length,
-          `Feature ${feature.shape} should have edge markers`,
-        ).toBeGreaterThan(0);
+        expect(markers.length, `Feature ${feature.shape} should have edge markers`).toBeGreaterThan(
+          0,
+        );
       }
     }
   });
@@ -108,9 +107,10 @@ test.describe('Shape Markers Helper', () => {
         featureId: lineFeature.id,
         temporary: false,
       });
-      expect(markers.length, 'Line should have markers when change mode is enabled').toBeGreaterThan(
-        0,
-      );
+      expect(
+        markers.length,
+        'Line should have markers when change mode is enabled',
+      ).toBeGreaterThan(0);
 
       // Disable change mode
       await disableMode(page, 'edit', 'change');

--- a/tests/helpers/zoom-to-features.spec.ts
+++ b/tests/helpers/zoom-to-features.spec.ts
@@ -57,21 +57,18 @@ test.describe('Zoom To Features Helper', () => {
 
     // Check that all feature centroids are within the map bounds
     for (const feature of features) {
-      const featureBounds = await page.evaluate(
-        (geoJson) => {
-          const bbox = window.turf?.bbox?.(geoJson);
-          if (bbox) {
-            return {
-              minLng: bbox[0],
-              minLat: bbox[1],
-              maxLng: bbox[2],
-              maxLat: bbox[3],
-            };
-          }
-          return null;
-        },
-        feature.geoJson,
-      );
+      const featureBounds = await page.evaluate((geoJson) => {
+        const bbox = window.turf?.bbox?.(geoJson);
+        if (bbox) {
+          return {
+            minLng: bbox[0],
+            minLat: bbox[1],
+            maxLng: bbox[2],
+            maxLat: bbox[3],
+          };
+        }
+        return null;
+      }, feature.geoJson);
 
       // Skip if we couldn't get feature bounds (turf might not be available on window)
       if (!featureBounds) continue;

--- a/tests/options/modes.spec.ts
+++ b/tests/options/modes.spec.ts
@@ -163,7 +163,16 @@ test.describe('GmOptions - Mode Management', () => {
 
   test.describe('isModeAvailable', () => {
     test('should return true for available draw modes', async () => {
-      const drawModes = ['marker', 'circle_marker', 'text_marker', 'line', 'polygon', 'rectangle', 'circle', 'ellipse'];
+      const drawModes = [
+        'marker',
+        'circle_marker',
+        'text_marker',
+        'line',
+        'polygon',
+        'rectangle',
+        'circle',
+        'ellipse',
+      ];
 
       for (const mode of drawModes) {
         const isAvailable = await page.evaluate((modeName) => {
@@ -273,7 +282,9 @@ test.describe('GmOptions - Mode Management', () => {
   test.describe('Mode switching', () => {
     test('should switch between draw modes', async () => {
       await enableMode(page, 'draw', 'marker');
-      expect(await page.evaluate(() => window.geoman.options.isModeEnabled('draw', 'marker'))).toBe(true);
+      expect(await page.evaluate(() => window.geoman.options.isModeEnabled('draw', 'marker'))).toBe(
+        true,
+      );
 
       await disableMode(page, 'draw', 'marker');
       await enableMode(page, 'draw', 'line');

--- a/tests/utils-tests/geojson.spec.ts
+++ b/tests/utils-tests/geojson.spec.ts
@@ -43,13 +43,10 @@ test.describe('GeoJSON Utility Functions', () => {
           ],
         },
       };
-      const result = await page.evaluate(
-        (feature) => {
-          const { isLineStringFeature } = window.geomanUtils;
-          return isLineStringFeature(feature);
-        },
-        lineFeature,
-      );
+      const result = await page.evaluate((feature) => {
+        const { isLineStringFeature } = window.geomanUtils;
+        return isLineStringFeature(feature);
+      }, lineFeature);
       expect(result).toBe(true);
     });
 
@@ -70,13 +67,10 @@ test.describe('GeoJSON Utility Functions', () => {
           ],
         },
       };
-      const result = await page.evaluate(
-        (feature) => {
-          const { isLineStringFeature } = window.geomanUtils;
-          return isLineStringFeature(feature);
-        },
-        polygonFeature,
-      );
+      const result = await page.evaluate((feature) => {
+        const { isLineStringFeature } = window.geomanUtils;
+        return isLineStringFeature(feature);
+      }, polygonFeature);
       expect(result).toBe(false);
     });
   });
@@ -99,13 +93,10 @@ test.describe('GeoJSON Utility Functions', () => {
           ],
         },
       };
-      const result = await page.evaluate(
-        (feature) => {
-          const { isPolygonFeature } = window.geomanUtils;
-          return isPolygonFeature(feature);
-        },
-        polygonFeature,
-      );
+      const result = await page.evaluate((feature) => {
+        const { isPolygonFeature } = window.geomanUtils;
+        return isPolygonFeature(feature);
+      }, polygonFeature);
       expect(result).toBe(true);
     });
   });
@@ -139,13 +130,10 @@ test.describe('GeoJSON Utility Functions', () => {
           ],
         },
       };
-      const result = await page.evaluate(
-        (feature) => {
-          const { isMultiPolygonFeature } = window.geomanUtils;
-          return isMultiPolygonFeature(feature);
-        },
-        multiPolygonFeature,
-      );
+      const result = await page.evaluate((feature) => {
+        const { isMultiPolygonFeature } = window.geomanUtils;
+        return isMultiPolygonFeature(feature);
+      }, multiPolygonFeature);
       expect(result).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary
- Run `npm run formatter:fix` to apply consistent code formatting
- Updated 11 files across source and test directories

## Test plan
- [ ] CI passes with formatted code
- [ ] No functional changes, formatting only