### PR TITLE
fix: race condition in waitForBaseMap causing initialization timeout

### DIFF
--- a/src/types/map/index.ts
+++ b/src/types/map/index.ts
@@ -107,6 +107,7 @@ export type BasePopupOptions = {
 
 export interface MapWithOnceMethod {
   once(type: string, listener: (ev: unknown) => void): this;
+  off(type: string, listener: (ev: unknown) => void): this;
 }
 
 export const mapInteractions = [


### PR DESCRIPTION
## Summary
- Fix race condition where map 'load' event fires between isLoaded() check and listener registration
- Add error handling for initialization failures with proper cleanup via destroy()
- Apply same fix to waitForGeomanLoaded()

Fixes #106

## Test plan
- [ ] Existing tests pass
- [ ] Test with cached resources to trigger fast map loads