### PR TITLE
Prioritize special shape when querying map features

### DIFF
--- a/src/core/features/index.ts
+++ b/src/core/features/index.ts
@@ -26,7 +26,7 @@ import {
   type ShapeName,
   type SourcesStorage,
 } from '@/main.ts';
-import { SPECIAL_SHAPE_NAMES } from '@/modes/constants';
+import { SPECIAL_SHAPE_NAMES } from '@/modes/constants.ts';
 import { fixGeoJsonFeature, getCustomFeatureId } from '@/utils/features.ts';
 import { getGeoJsonBounds } from '@/utils/geojson.ts';
 import { isMapPointerEvent } from '@/utils/guards/map.ts';


### PR DESCRIPTION
Hi!
Yesterday I experienced an issue in EditChange mode. Unfortunately, I'm not able to reproduce the bug in a video, but I can explain it.

- Go to ChangeMode
- Click on a shape marker (center_marker, vertex_marker or edge_marker) to move a vertex and move your cursor.

If you click on a shape marker inside a polygon and call `mapAdapter.queryFeaturesByScreenCoordinates`, you get an array of 2 features:
- the vertex_marker feature data
- the polygon feature data (parent of the vertex_marker)

Most of the time, the vertex_marker appears first, and when querying `features.getFeatureByMouseEvent`, the `vertex_marker` is returned. However, in some cases (not able to reproduce this morning), the `vertex_marker` doesn't appear first and the polygon feature data is returned from `features.getFeatureByMouseEvent` instead.

**As a consequence, when we try to move a vertex by clicking and dragging it, the entire feature is translated.**

This PR solves this issue by checking if there is a special shape when we call `features.getFeatureByMouseEvent` and prioritizing this feature.
 in priority.


The video highlight in which case the bug can appear but doesn't reproduce the bug (sorry)

array of features returned by `queryFeaturesByScreenCoordinates`: 
- `[<shape-marker>, <feature>]`
in some case it can be `[<feature>, <shape-marker>]`

https://github.com/user-attachments/assets/411724c2-8b65-4b83-bb04-bacb6514a0b9



