### PR TITLE
Allow closing polygon by double clicking last placed marker

### DIFF
--- a/src/modes/draw/polygon.ts
+++ b/src/modes/draw/polygon.ts
@@ -31,6 +31,7 @@ export class DrawPolygon extends BaseDraw {
   onStartAction(): void {
     this.lineDrawer.startAction();
     this.lineDrawer.on('firstMarkerClick', this.polygonFinished.bind(this));
+    this.lineDrawer.on('lastMarkerClick', this.polygonFinished.bind(this));
   }
 
   onMouseMove(event: BaseMapEvent) {


### PR DESCRIPTION
## Summary

- Allow closing a polygon by clicking on the last placed marker, mirroring the existing behavior of the line drawer
- When drawing a polygon, the user can now click on the last vertex to finalize the shape, in addition to clicking on the first vertex
- This provides a consistent UX between line and polygon drawing modes

## Context

Closes #129

When drawing a line, clicking on the last placed marker finishes the shape. Users naturally expect the same behavior when drawing a polygon, but previously the only way to close a polygon was to click on the first vertex.
