### PR TITLE
chore: bump maplibre peer dependency to 5.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "vite-svg-loader": "^5.1.0"
       },
       "peerDependencies": {
-        "maplibre-gl": "5.17.0"
+        "maplibre-gl": "5.18.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "type-fest": "^5.4.4"
   },
   "peerDependencies": {
-    "maplibre-gl": "5.17.0"
+    "maplibre-gl": "5.18.0"
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.2",


### PR DESCRIPTION
## Summary
- bump peerDependencies.maplibre-gl from 5.17.0 to 5.18.0
- sync root peer dependency metadata in package-lock.json

## Validation
- npm run ts