### PR TITLE
Cursor management improvements

### DIFF
--- a/packages/core/src/core/options/defaults/free.ts
+++ b/packages/core/src/core/options/defaults/free.ts
@@ -10,6 +10,7 @@ export const defaultOptions: GmOptionsData = {
     throttlingDelay: 10,
     awaitDataUpdatesOnEvents: true,
     useDefaultLayers: true,
+    useCursorHandlers: true,
     useControlsUi: true,
     controlsPosition: 'top-left',
     controlsUiEnabledByDefault: true,

--- a/packages/core/src/modes/edit/base.ts
+++ b/packages/core/src/modes/edit/base.ts
@@ -27,7 +27,13 @@ export abstract class BaseEdit extends BaseAction {
   actionType: ActionType = 'edit';
   abstract mode: EditModeName;
   featureData: FeatureData | null = null;
-  cursorExcludedLayerIds: Array<string> = ['rectangle-line', 'polygon-line', 'circle-line'];
+  cursorExcludedLayerIds: Array<string> = [
+    'polygon__line',
+    'ellipse__line',
+    'rectangle__line',
+    'circle__line',
+    'snap_guide__line',
+  ];
   layerEventHandlersData: Array<{
     eventName: PointerEventName;
     layerId: string;
@@ -78,6 +84,9 @@ export abstract class BaseEdit extends BaseAction {
   }
 
   setEventsForLayers(eventName: PointerEventName, callback: () => void) {
+    if (!this.gm.options.settings.useCursorHandlers) {
+      return;
+    }
     const targetLayerIds = this.gm.features.layers
       .map((layer) => layer.id)
       .filter(

--- a/packages/core/src/styles/style.css
+++ b/packages/core/src/styles/style.css
@@ -62,3 +62,28 @@
 .marker-wrapper {
   cursor: pointer;
 }
+
+:is(
+  .maplibregl-canvas-container.maplibregl-interactive,
+  .mapboxgl-canvas-container.mapboxgl-interactive
+).gm-cursor-move {
+  cursor: move;
+}
+:is(
+  .maplibregl-canvas-container.maplibregl-interactive,
+  .mapboxgl-canvas-container.mapboxgl-interactive
+).gm-cursor-pointer {
+  cursor: pointer;
+}
+:is(
+  .maplibregl-canvas-container.maplibregl-interactive,
+  .mapboxgl-canvas-container.mapboxgl-interactive
+).gm-cursor-grab {
+  cursor: grab;
+}
+:is(
+  .maplibregl-canvas-container.maplibregl-interactive,
+  .mapboxgl-canvas-container.mapboxgl-interactive
+).gm-cursor-crosshair {
+  cursor: crosshair;
+}

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -47,6 +47,7 @@ export type GmOptionsData = {
      */
     awaitDataUpdatesOnEvents: boolean;
     useDefaultLayers: boolean;
+    useCursorHandlers: boolean;
     useControlsUi: boolean;
     controlsPosition: BaseControlsPosition;
     controlsUiEnabledByDefault: boolean;

--- a/packages/mapbox/src/adapter/index.ts
+++ b/packages/mapbox/src/adapter/index.ts
@@ -111,7 +111,11 @@ export class MapboxAdapter extends BaseMapAdapter<
   }
 
   setCursor(cursor: CursorType) {
-    this.mapInstance.getCanvas().style.cursor = cursor;
+    const cursorTypes: CursorType[] = ['pointer', 'move', 'grab', 'crosshair'];
+    const container = this.mapInstance.getCanvasContainer();
+    cursorTypes.forEach((c) => {
+      container.classList.toggle(`gm-cursor-${c}`, c === cursor);
+    });
   }
 
   disableMapInteractions(interactionTypes: Array<MapInteraction>): void {

--- a/packages/maplibre/src/adapter/index.ts
+++ b/packages/maplibre/src/adapter/index.ts
@@ -99,7 +99,11 @@ export class MaplibreAdapter extends BaseMapAdapter<ml.Map, ml.GeoJSONSource, Ma
   }
 
   setCursor(cursor: CursorType) {
-    this.mapInstance.getCanvas().style.cursor = cursor;
+    const cursorTypes: CursorType[] = ['pointer', 'move', 'grab', 'crosshair'];
+    const container = this.mapInstance.getCanvasContainer();
+    cursorTypes.forEach((c) => {
+      container.classList.toggle(`gm-cursor-${c}`, c === cursor);
+    });
   }
 
   disableMapInteractions(interactionTypes: Array<MapInteraction>): void {


### PR DESCRIPTION
Hi 👋,

A little PR related to cursor...

### What's fixed

A bug was preventing the cursor from updating correctly when hovering over features in edit mode, the `cursorExcludedLayerIds` in `BaseEdit` were referencing outdated layer identifiers (`rectangle-line`, `polygon-line` ) that no longer matched the current naming convention (`polygon__line`, `rectangle__line`, `ellipse__line`).
This is now fixed!

### Class-based cursor management

The `setCursor` method in both the MapLibre and Mapbox adapters no longer sets `style.cursor` directly on the canvas element. Instead, it toggles CSS classes (`gm-cursor-move`, `gm-cursor-pointer`, `gm-cursor-grab`, `gm-cursor-crosshair`) on the canvas container.

This aligns with how MapLibre and Mapbox handle cursors natively, avoid conflicts, and brings a nice bonus: cursors can now be customized through CSS without touching any JavaScript. Great for integrations that have their own design system!

### New `useCursorHandlers` option

If you have created your own layers with IDs that don't follow geoman's internal naming conventions, hover events might be misinterpreted and trigger unexpected cursor updates. In that case, simply set `useCursorHandlers: false` to take full control of cursor management on the application side.
