### PR TITLE
chore: refresh remaining dependency updates

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -209,7 +209,7 @@ jobs:
 
     steps:
       - name: Create PR comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo, number } = context.issue;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
         uses: ffurrer2/extract-release-notes@v3
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ needs.validate.outputs.version }}
           tag_name: v${{ needs.validate.outputs.version }}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "ts-autofix": "^1.0.0",
     "tsc-alias": "^1.8.17",
     "turbo": "^2.9.9",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.11",
     "vite-svg-loader": "^5.1.1",
     "vitest": "^4.1.5"

--- a/packages/mapbox/tsconfig.types.json
+++ b/packages/mapbox/tsconfig.types.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.mapbox.json",
   "compilerOptions": {
     "outDir": "./dist/types",
+    "rootDir": "../..",
     "paths": {
       "@/*": ["packages/core/src/*"],
       "@dev/*": ["apps/dev/*"],

--- a/packages/maplibre/tsconfig.types.json
+++ b/packages/maplibre/tsconfig.types.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.maplibre.json",
   "compilerOptions": {
     "outDir": "./dist/types",
+    "rootDir": "../..",
     "paths": {
       "@/*": ["packages/core/src/*"],
       "@dev/*": ["apps/dev/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,7 +158,7 @@ importers:
         version: 4.61.1
       rollup-plugin-dts:
         specifier: ^6.4.1
-        version: 6.4.1(rollup@4.61.1)(typescript@5.9.3)
+        version: 6.4.1(rollup@4.61.1)(typescript@6.0.3)
       sass:
         specifier: ^1.99.0
         version: 1.100.0
@@ -170,7 +170,7 @@ importers:
         version: 5.56.3
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.5(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@5.9.3)
+        version: 6.0.5(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@6.0.3)
       ts-autofix:
         specifier: ^1.0.0
         version: 1.0.0
@@ -181,14 +181,14 @@ importers:
         specifier: ^2.9.9
         version: 2.9.16
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.0.11
         version: 8.0.16(@types/node@25.9.2)(sass@1.100.0)
       vite-svg-loader:
         specifier: ^5.1.1
-        version: 5.1.1(vue@3.5.35(typescript@5.9.3))
+        version: 5.1.1(vue@3.5.35(typescript@6.0.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(sass@1.100.0))
@@ -2284,8 +2284,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3392,11 +3392,11 @@ snapshots:
       '@vue/shared': 3.5.35
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.35
       '@vue/shared': 3.5.35
-      vue: 3.5.35(typescript@5.9.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   '@vue/shared@3.5.35': {}
 
@@ -4082,14 +4082,14 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
-  rollup-plugin-dts@6.4.1(rollup@4.61.1)(typescript@5.9.3):
+  rollup-plugin-dts@6.4.1(rollup@4.61.1)(typescript@6.0.3):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       convert-source-map: 2.0.0
       magic-string: 0.30.21
       rollup: 4.61.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       '@babel/code-frame': 7.29.7
 
@@ -4196,13 +4196,13 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-preprocess@6.0.5(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@5.9.3):
+  svelte-preprocess@6.0.5(postcss@8.5.15)(sass@1.100.0)(svelte@5.56.3)(typescript@6.0.3):
     dependencies:
       svelte: 5.56.3
     optionalDependencies:
       postcss: 8.5.15
       sass: 1.100.0
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   svelte@5.56.3:
     dependencies:
@@ -4296,15 +4296,15 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
 
-  vite-svg-loader@5.1.1(vue@3.5.35(typescript@5.9.3)):
+  vite-svg-loader@5.1.1(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       debug: 4.4.3
       svgo: 3.3.3
-      vue: 3.5.35(typescript@5.9.3)
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4351,15 +4351,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vue@3.5.35(typescript@5.9.3):
+  vue@3.5.35(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.35
       '@vue/compiler-sfc': 3.5.35
       '@vue/runtime-dom': 3.5.35
-      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.35
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   wcwidth@1.0.1:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "outDir": "./dist/types",
     "target": "ES2022",


### PR DESCRIPTION
## Summary
- Update the still-relevant Dependabot PRs: actions/github-script v9 (#186), softprops/action-gh-release v3 (#185), and TypeScript ^6.0.3 (#197).
- Add the TypeScript 6 config updates needed for the existing workspace/type declaration build.
- Leave the package peer floors unchanged; the older dependency PRs (#177-#183 and #190) are already superseded by current master.

## Verification
- env CI=true pnpm install --frozen-lockfile
- pnpm run formatter
- pnpm run workspace:validate
- pnpm run lint:all
- pnpm run typecheck:all
- pnpm run test:unit
- pnpm run build:all
- pnpm run test:maplibre --project=chromium
- pnpm run test:mapbox --project=chromium

Note: an initial full MapLibre Chromium run had one timeout in `Text marker create event`; the focused create spec and the subsequent full MapLibre Chromium rerun both passed.