### PR TITLE
ci: use Playwright chrome channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,17 +148,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Use runner Chromium
-        run: |
-          for browser in google-chrome-stable google-chrome chromium chromium-browser; do
-            if command -v "$browser" >/dev/null 2>&1; then
-              echo "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v "$browser")" >> "$GITHUB_ENV"
-              exit 0
-            fi
-          done
-          echo "No system Chromium/Chrome executable found on large-test-runner"
-          exit 1
-
       - name: Run Playwright tests
         run: |
           if [[ "${{ matrix.variant }}" == "mapbox" ]]; then

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -141,17 +141,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Use runner Chromium
-        run: |
-          for browser in google-chrome-stable google-chrome chromium chromium-browser; do
-            if command -v "$browser" >/dev/null 2>&1; then
-              echo "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v "$browser")" >> "$GITHUB_ENV"
-              exit 0
-            fi
-          done
-          echo "No system Chromium/Chrome executable found on runner"
-          exit 1
-
       - name: Run smoke tests
         run: |
           if [[ "${{ matrix.variant }}" == "mapbox" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- CI and dev e2e jobs now run Playwright against the system Chrome stable preinstalled on GitHub runner images (`channel: 'chrome'` on CI) instead of downloading a Playwright-managed Chromium. Large downloads on hosted runners began stalling mid-transfer on 2026-06-12, hanging the `playwright install` step indefinitely; local runs keep the pinned Playwright-managed browser.
+
 ### Changed
 
 - Upgraded the workspace package manager from pnpm 10 to pnpm 11 (`onlyBuiltDependencies` -> `allowBuilds`, `overrides` moved from `package.json#pnpm` to `pnpm-workspace.yaml`, lockfile re-resolved under the seven-day `minimumReleaseAge` policy)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,6 +57,10 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        // On CI, run against the system-installed Chrome stable (preinstalled on
+        // GitHub runner images) instead of downloading a Playwright-managed
+        // Chromium, which is blocked by unreliable runner egress for large
+        // downloads. Local runs keep the pinned Playwright-managed browser.
         channel: process.env.CI ? 'chrome' : undefined,
         headless: true,
         launchOptions: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,6 @@ const playwrightVariant = playwrightVariantRaw as 'maplibre' | 'mapbox';
 const testServerCommand =
   playwrightVariant === 'mapbox' ? 'pnpm run testserver:mapbox' : 'pnpm run testserver:maplibre';
 const testServerPort = playwrightVariant === 'mapbox' ? 4001 : 4000;
-const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
 
 /**
  * Read environment variables from file.
@@ -58,9 +57,9 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        channel: process.env.CI ? 'chrome' : undefined,
         headless: true,
         launchOptions: {
-          ...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
           args: [
             // Force software WebGL so map rendering works in headless/sandboxed environments.
             '--use-angle=swiftshader',


### PR DESCRIPTION
## Summary
- remove custom Chrome executable discovery from CI and dev workflows
- use Playwright's native chrome channel on CI
- keep local runs on Playwright-managed Chromium

## Validation
- pnpm run formatter
- pnpm run workspace:validate
- pre-push: lint, typecheck, unit tests, audit