### PR TITLE
fix(features): allow importGeoJsonFeature without a properties field

### DIFF
--- a/packages/core/src/core/features/index.ts
+++ b/packages/core/src/core/features/index.ts
@@ -366,7 +366,7 @@ export class Features {
 
     const id =
       featureId ??
-      shapeGeoJson.properties[FEATURE_ID_PROPERTY] ??
+      shapeGeoJson.properties?.[FEATURE_ID_PROPERTY] ??
       this.getNewFeatureId(shapeGeoJson);
 
     if (!propertiesValid(shapeGeoJson)) {

--- a/tests/features/crud.spec.ts
+++ b/tests/features/crud.spec.ts
@@ -35,6 +35,29 @@ test.describe('Feature Management - CRUD Operations', () => {
       expect(features[0].shape).toBe('marker');
     });
 
+    test('should import a GeoJSON feature without a properties field', async () => {
+      // regression: importGeoJsonFeature must not require `properties` (issue #195)
+      const featureWithoutProperties = {
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [3, 52] as LngLatTuple,
+        },
+      };
+
+      const result = await page.evaluate(async (feature) => {
+        return window.geoman.features.importGeoJsonFeature(
+          feature as unknown as GeoJsonImportFeature,
+        );
+      }, featureWithoutProperties);
+
+      expect(result, 'Should return a feature data object').not.toBeNull();
+
+      const features = await getRenderedFeaturesData({ page, temporary: false });
+      expect(features.length).toBe(1);
+      expect(features[0].shape).toBe('marker');
+    });
+
     test('should import multiple GeoJSON features', async () => {
       const featureCollection = {
         type: 'FeatureCollection' as const,


### PR DESCRIPTION
## Problem

`importGeoJsonFeature` (and `createFeature`) threw `TypeError: Cannot read properties of undefined (reading '__gm_id')` when given a feature that omits `properties`, e.g.:

```js
map.gm.features.importGeoJsonFeature({
  type: 'Feature',
  geometry: { type: 'Point', coordinates: [3, 52] },
});
```

GeoJSON `Feature.properties` is `P | null` and is commonly `undefined` at runtime, but `createFeature` indexed it unconditionally when resolving the feature id.

## Fix

Guard the property access with optional chaining so it falls back to `getNewFeatureId`:

```diff
-      shapeGeoJson.properties[FEATURE_ID_PROPERTY] ??
+      shapeGeoJson.properties?.[FEATURE_ID_PROPERTY] ??
```

The rest of the pipeline already tolerates missing properties (`getFeatureShapeByGeoJson` uses `properties?.shape`; `FeatureData` rebuilds props from `geoJson.properties || {}`).

## Tests

Added an e2e regression test importing a `properties`-less Point. Confirmed it fails with the exact error before the fix and passes after (verified against the identical line/test). Typecheck, oxlint, and format are clean.

Fixes #195