### PR TITLE
chore(deps): bump dompurify to ^3.4.11 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@turf/transform-scale": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/unkink-polygon": "^7.3.5",
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.11",
     "lodash-es": "^4.18.1",
     "loglevel": "^1.9.2",
     "type-fest": "^5.6.0"

--- a/packages/mapbox/package.json
+++ b/packages/mapbox/package.json
@@ -76,7 +76,7 @@
     "@turf/union": "^7.3.5",
     "@turf/unkink-polygon": "^7.3.5",
     "@types/geojson": "^7946.0.16",
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.11",
     "lodash-es": "^4.18.1",
     "loglevel": "^1.9.2",
     "type-fest": "^5.6.0"

--- a/packages/maplibre/package.json
+++ b/packages/maplibre/package.json
@@ -76,7 +76,7 @@
     "@turf/union": "^7.3.5",
     "@turf/unkink-polygon": "^7.3.5",
     "@types/geojson": "^7946.0.16",
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.11",
     "lodash-es": "^4.18.1",
     "loglevel": "^1.9.2",
     "type-fest": "^5.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^7.3.5
         version: 7.3.5
       dompurify:
-        specifier: ^3.4.2
-        version: 3.4.8
+        specifier: ^3.4.11
+        version: 3.4.11
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -293,8 +293,8 @@ importers:
         specifier: ^7946.0.16
         version: 7946.0.16
       dompurify:
-        specifier: ^3.4.2
-        version: 3.4.8
+        specifier: ^3.4.11
+        version: 3.4.11
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -401,8 +401,8 @@ importers:
         specifier: ^7946.0.16
         version: 7946.0.16
       dompurify:
-        specifier: ^3.4.2
-        version: 3.4.8
+        specifier: ^3.4.11
+        version: 3.4.11
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1563,8 +1563,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3687,7 +3687,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.8:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary

Bumps `dompurify` from `^3.4.2` (resolved 3.4.8) to `^3.4.11` across the workspace root, `packages/maplibre`, and `packages/mapbox`, fixing two advisories flagged by `pnpm audit`:

- **Moderate** — [GHSA-cmwh-pvxp-8882](https://github.com/advisories/GHSA-cmwh-pvxp-8882): permanent `ALLOWED_ATTR` pollution via `setConfig()` bypassing the hook clone-guard (vulnerable `<=3.4.10`).
- **Low** — [GHSA-vxr8-fq34-vvx9](https://github.com/advisories/GHSA-vxr8-fq34-vvx9): Trusted Types policy survives `clearConfig()` and can poison later `RETURN_TRUSTED_TYPE` output (vulnerable `<3.4.9`).

`3.4.11` is the current latest release and is ~8 days old, comfortably past a 24h release cooldown.

## Verification

```
$ pnpm audit --audit-level=low
No known vulnerabilities found
```