### PR TITLE
fix(edit): preserve polygon/line dimensions when dragging (#172)

### DIFF
--- a/packages/core/src/modes/edit/base-drag.ts
+++ b/packages/core/src/modes/edit/base-drag.ts
@@ -3,13 +3,18 @@ import { FEATURE_PROPERTY_PREFIX, SOURCES } from '@/core/features/constants.ts';
 import { FeatureData } from '@/core/features/feature-data.ts';
 import type { MapHandlerReturnData } from '@/types/events/bus.ts';
 import type { GmSystemEvent } from '@/types/events/index.ts';
-import type { FeatureShape } from '@/types/features.ts';
+import type { FeatureId, FeatureShape } from '@/types/features.ts';
 import type { GeoJsonShapeFeature, SimplePoint } from '@/types/geojson.ts';
 import type { LngLatTuple } from '@/types/map/index.ts';
 import type { EditModeName } from '@/types/modes/index.ts';
 import { BaseEdit } from '@/modes/edit/base.ts';
 import { convertToThrottled } from '@/utils/behavior.ts';
-import { getFeatureFirstPoint, getMovedGeoJson, getShapeProperties } from '@/utils/features.ts';
+import {
+  getFeatureFirstPoint,
+  getMovedGeoJson,
+  getShapeProperties,
+  getTranslatedGeoJson,
+} from '@/utils/features.ts';
 import {
   getGeoJsonCircle,
   getGeoJsonEllipse,
@@ -19,7 +24,7 @@ import {
 import { isMapPointerEvent } from '@/utils/guards/map.ts';
 import type { BaseMapEvent } from '@mapLib/types/events.ts';
 import type { Feature, Polygon } from 'geojson';
-import { isEqual } from 'lodash-es';
+import { cloneDeep, isEqual } from 'lodash-es';
 import log from 'loglevel';
 import { moveRectangle } from '@/utils/shapes.ts';
 
@@ -34,6 +39,16 @@ export abstract class BaseDrag extends BaseEdit {
   initialPoint: SimplePoint | null = null;
   previousLngLat: LngLatTuple | null = null;
   linkedFeatures: Array<FeatureData> = [];
+
+  /**
+   * Drag-start state for the geodesic (polygon/line) translation path. The anchor
+   * is the pointer position when the drag began; the snapshot map holds each
+   * dragged feature's pristine geometry. On every pointer tick we translate the
+   * snapshot by the *total* anchor→cursor vector rather than mutating the live
+   * geometry incrementally, which avoids cumulative reprojection drift (#172).
+   */
+  dragAnchorLngLat: LngLatTuple | null = null;
+  pristineGeoJsons: Map<FeatureId, GeoJsonShapeFeature> = new Map();
 
   /**
    * When true, clicking and dragging the feature body directly (not a marker)
@@ -71,9 +86,9 @@ export abstract class BaseDrag extends BaseEdit {
     circle: this.moveCircle.bind(this),
     circle_marker: this.moveSource.bind(this),
     text_marker: this.moveSource.bind(this),
-    line: this.moveSource.bind(this),
+    line: this.moveGeodesic.bind(this),
     rectangle: this.moveRectangle.bind(this),
-    polygon: this.moveSource.bind(this),
+    polygon: this.moveGeodesic.bind(this),
   };
 
   async onMouseDown(event: BaseMapEvent) {
@@ -96,6 +111,17 @@ export abstract class BaseDrag extends BaseEdit {
       this.initialPoint = event.point;
       this.featureData = featureData;
       this.linkedFeatures = linkedFeatures;
+
+      // Snapshot pristine geometry for the geodesic path. The anchor is captured
+      // lazily on the first pointer move so it shares the exact source (marker
+      // pointer vs raw cursor) used for the per-tick target position.
+      this.dragAnchorLngLat = null;
+      this.pristineGeoJsons = new Map(
+        [this.featureData, ...this.linkedFeatures].map((fd) => [
+          fd.id,
+          cloneDeep(fd.getGeoJson()) as GeoJsonShapeFeature,
+        ]),
+      );
 
       this.gm.features.updateManager.beginTransaction('transactional-update');
 
@@ -153,6 +179,8 @@ export abstract class BaseDrag extends BaseEdit {
     this.previousLngLat = null;
     this.featureData = null;
     this.linkedFeatures = [];
+    this.dragAnchorLngLat = null;
+    this.pristineGeoJsons = new Map();
     return { next: true };
   }
 
@@ -166,6 +194,12 @@ export abstract class BaseDrag extends BaseEdit {
       // see "relatedModes" in options
       const lngLatEnd = this.gm.markerPointer.marker?.getLngLat() || event.lngLat.toArray();
       const lngLatStart = this.previousLngLat ?? lngLatEnd;
+
+      // Anchor the geodesic translation at the first observed pointer position so
+      // the total drag vector is measured from where the geometry actually started.
+      if (!this.dragAnchorLngLat) {
+        this.dragAnchorLngLat = lngLatEnd;
+      }
 
       this.gm.features.updateManager.beginTransaction('transactional-update', SOURCES.temporary);
 
@@ -237,6 +271,31 @@ export abstract class BaseDrag extends BaseEdit {
 
   moveSource(featureData: FeatureData, startLngLat: LngLatTuple, endLngLat: LngLatTuple) {
     return getMovedGeoJson(featureData, getLngLatDiff(startLngLat, endLngLat));
+  }
+
+  /**
+   * Dimension-preserving translation for polygons and lines: keeps edge lengths and
+   * area intact at any latitude by rebuilding the geometry from anchor-relative
+   * geodesic offsets, matching how circles/ellipses/rectangles are reconstructed
+   * from metric properties (#172). Translates the pristine drag-start snapshot by
+   * the total anchor→cursor vector to avoid cumulative drift.
+   */
+  moveGeodesic(
+    featureData: FeatureData,
+    startLngLat: LngLatTuple,
+    endLngLat: LngLatTuple,
+  ): GeoJsonShapeFeature {
+    const pristineGeoJson = this.pristineGeoJsons.get(featureData.id);
+    const anchorLngLat = this.dragAnchorLngLat;
+
+    if (!pristineGeoJson || !anchorLngLat) {
+      // No snapshot/anchor (e.g. invoked outside a pointer drag) — fall back to the
+      // legacy incremental degree-offset translation rather than dropping the move.
+      log.warn('BaseDrag.moveGeodesic: missing drag snapshot, using incremental move', featureData);
+      return this.moveSource(featureData, startLngLat, endLngLat);
+    }
+
+    return getTranslatedGeoJson(pristineGeoJson, anchorLngLat, endLngLat);
   }
 
   moveRectangle(

--- a/packages/core/src/utils/features.ts
+++ b/packages/core/src/utils/features.ts
@@ -10,8 +10,10 @@ import {
   getAllGeoJsonCoordinates,
   getGeoJsonFirstPoint,
 } from '@/utils/geojson.ts';
+import bearing from '@turf/bearing';
 import { booleanPointInPolygon } from '@turf/boolean-point-in-polygon';
 import buffer from '@turf/buffer';
+import destination from '@turf/destination';
 import distance from '@turf/distance';
 import lineIntersect from '@turf/line-intersect';
 import rewind from '@turf/rewind';
@@ -108,6 +110,55 @@ export const getMovedGeoJson = (featureData: FeatureData, lngLatDiff: LngLatDiff
   const featureGeoJson = cloneDeep(featureData.getGeoJson() as GeoJsonShapeFeature);
   moveGeoJson(featureGeoJson, lngLatDiff);
   return featureGeoJson;
+};
+
+// Below this many meters of drag we treat the move as a no-op and return the
+// snapshot untouched (avoids needless re-projection of every vertex).
+const TRANSLATE_EPSILON_METERS = 1e-6;
+
+/**
+ * Translate a whole feature so it keeps its real-world shape and dimensions — the
+ * same metric philosophy circles/ellipses already use (radius in meters). This is
+ * the polygon/line analog of reconstructing a circle from its center + radius:
+ * each vertex is stored as a geodesic (distance, bearing) offset from the drag
+ * anchor, then rebuilt around the new anchor position.
+ *
+ * Why not a constant degree offset (`moveGeoJson`)? A degree offset is a rigid
+ * rotation of the sphere for pure east/west drags, but for any north/south
+ * component it shears the shape — horizontal edges land at a latitude where their
+ * degree-span is a different number of meters, so edge lengths and area drift
+ * (~3% over ~100 km near 60°N). Reconstructing from anchor-relative geodesic
+ * offsets preserves edges and area to within rounding at any latitude, and was
+ * empirically the only translation that does (a Web-Mercator offset is worse, and
+ * Turf's `transformTranslate` is no better than the degree offset). See issue #172.
+ *
+ * IMPORTANT: always pass the *pristine* (drag-start) geometry and the *total*
+ * anchor→target vector. Recomputing offsets from an already-moved geometry every
+ * pointer tick accumulates drift over a long drag; rebuilding the snapshot from the
+ * absolute anchor→target vector does not.
+ */
+export const getTranslatedGeoJson = (
+  pristineGeoJson: GeoJsonShapeFeature,
+  anchorLngLat: LngLatTuple,
+  targetLngLat: LngLatTuple,
+): GeoJsonShapeFeature => {
+  const cloned = cloneDeep(pristineGeoJson);
+  if (distance(anchorLngLat, targetLngLat, { units: 'meters' }) < TRANSLATE_EPSILON_METERS) {
+    return cloned;
+  }
+
+  eachCoordinateWithPath(cloned, (position) => {
+    const vertex = position.coordinate;
+    const offsetDistance = distance(anchorLngLat, vertex, { units: 'meters' });
+    const offsetBearing = bearing(anchorLngLat, vertex);
+    const [movedLng, movedLat] = destination(targetLngLat, offsetDistance, offsetBearing, {
+      units: 'meters',
+    }).geometry.coordinates;
+    position.coordinate[0] = movedLng;
+    position.coordinate[1] = movedLat;
+  });
+
+  return cloned;
 };
 
 export const moveFeatureData = async (featureData: FeatureData, lngLatDiff: LngLatDiff) => {

--- a/packages/core/test/unit/features-translate.spec.ts
+++ b/packages/core/test/unit/features-translate.spec.ts
@@ -1,0 +1,135 @@
+import area from '@turf/area';
+import distance from '@turf/distance';
+import type { Feature, Polygon, Position } from 'geojson';
+import { describe, expect, it, vi } from 'vitest';
+
+// '@/utils/features.ts' value-imports BaseMapAdapter (pulls in Svelte controls)
+// and '@tests/types.ts'; mock both to keep this spec node-only.
+vi.mock('@/core/map/base/index.ts', () => ({
+  BaseMapAdapter: class {},
+}));
+vi.mock('@tests/types.ts', () => ({
+  isLineBasedGeoJsonFeature: (geoJson: { geometry?: { type?: string } }) =>
+    ['LineString', 'MultiLineString'].includes(geoJson?.geometry?.type ?? ''),
+  isPointBasedGeoJsonFeature: (geoJson: { geometry?: { type?: string } }) =>
+    ['Point', 'MultiPoint'].includes(geoJson?.geometry?.type ?? ''),
+}));
+
+import { getTranslatedGeoJson, moveGeoJson } from '@/utils/features.ts';
+import type { GeoJsonShapeFeature } from '@/types/geojson.ts';
+import type { LngLatTuple } from '@/types/map/index.ts';
+
+// A tall, narrow polygon spanning 58°–62°N — the latitude band where translating
+// with a degree offset shears the shape the most.
+const makeTallPolygon = (): Feature<Polygon> => ({
+  type: 'Feature',
+  properties: { __gm_shape: 'polygon' },
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [10, 58],
+        [10.4, 58],
+        [10.4, 62],
+        [10, 62],
+        [10, 58],
+      ],
+    ],
+  },
+});
+
+const ring = (feature: Feature<Polygon>): Position[] => feature.geometry.coordinates[0];
+
+const edgeLengths = (feature: Feature<Polygon>): number[] => {
+  const coords = ring(feature);
+  const lengths: number[] = [];
+  for (let i = 0; i < coords.length - 1; i++) {
+    lengths.push(distance(coords[i], coords[i + 1], { units: 'meters' }));
+  }
+  return lengths;
+};
+
+const relErr = (a: number, b: number): number => Math.abs(a - b) / b;
+
+describe('utils/features getTranslatedGeoJson', () => {
+  const anchor: LngLatTuple = [10.2, 60];
+
+  // The hard case for a degree offset: a drag with a large north/south component.
+  describe.each<[string, LngLatTuple]>([
+    ['north', [10.2, 61]],
+    ['diagonal', [11.5, 61]],
+    ['east', [11.5, 60]],
+  ])('dragging %s', (_label, target) => {
+    it('preserves every edge length at ~60°N', () => {
+      const before = edgeLengths(makeTallPolygon());
+      const moved = getTranslatedGeoJson(
+        makeTallPolygon() as GeoJsonShapeFeature,
+        anchor,
+        target,
+      ) as Feature<Polygon>;
+      const after = edgeLengths(moved);
+
+      expect(after).toHaveLength(before.length);
+      after.forEach((len, i) => expect(relErr(len, before[i])).toBeLessThan(0.001));
+    });
+
+    it('preserves area', () => {
+      const before = area(makeTallPolygon());
+      const moved = getTranslatedGeoJson(makeTallPolygon() as GeoJsonShapeFeature, anchor, target);
+      expect(relErr(area(moved as Feature<Polygon>), before)).toBeLessThan(0.001);
+    });
+
+    it('actually moves the polygon (anchor lands on the target)', () => {
+      const moved = getTranslatedGeoJson(
+        makeTallPolygon() as GeoJsonShapeFeature,
+        anchor,
+        target,
+      ) as Feature<Polygon>;
+      // The polygon's centroid-ish first vertex should have shifted toward target.
+      expect(ring(moved)[0]).not.toEqual([10, 58]);
+    });
+  });
+
+  it('fixes the distortion the legacy degree-offset translation introduces', () => {
+    // Pure north drag — where adding a constant (Δlng, Δlat) to every vertex
+    // shears the shape because parallels shrink toward the pole.
+    const target: LngLatTuple = [10.2, 61];
+    const before = area(makeTallPolygon());
+
+    const naive = moveGeoJson(makeTallPolygon() as GeoJsonShapeFeature, {
+      lng: target[0] - anchor[0],
+      lat: target[1] - anchor[1],
+    });
+    const geodesic = getTranslatedGeoJson(makeTallPolygon() as GeoJsonShapeFeature, anchor, target);
+
+    const naiveError = relErr(area(naive as Feature<Polygon>), before);
+    const geodesicError = relErr(area(geodesic as Feature<Polygon>), before);
+
+    expect(naiveError).toBeGreaterThan(0.01); // legacy distorts (~3% here)
+    expect(geodesicError).toBeLessThan(0.001); // reconstruction holds the shape
+  });
+
+  it('is deterministic: output depends only on the geographic inputs', () => {
+    // No map/projection argument is involved, so globe and mercator views feed the
+    // same anchor/target and get byte-identical geometry.
+    const target: LngLatTuple = [11.5, 61];
+    const a = getTranslatedGeoJson(makeTallPolygon() as GeoJsonShapeFeature, anchor, target);
+    const b = getTranslatedGeoJson(makeTallPolygon() as GeoJsonShapeFeature, anchor, target);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('treats a zero-length drag as a no-op (no NaN from an undefined bearing)', () => {
+    const original = makeTallPolygon();
+    const moved = getTranslatedGeoJson(original as GeoJsonShapeFeature, anchor, anchor);
+    expect(moved.geometry).toEqual(original.geometry);
+  });
+
+  it('preserves feature properties through the translation', () => {
+    const moved = getTranslatedGeoJson(
+      makeTallPolygon() as GeoJsonShapeFeature,
+      anchor,
+      [11.5, 61],
+    );
+    expect(moved.properties).toEqual({ __gm_shape: 'polygon' });
+  });
+});


### PR DESCRIPTION
## Problem

Dragging a **polygon** or **line** translated every vertex by a constant degree offset (`moveGeoJson`):

```ts
lngLat[0] += lngLatDiff.lng;
lngLat[1] += lngLatDiff.lat;
```

That's a rigid rotation of the sphere for pure **east/west** drags, but any **north/south** component shears the shape — vertices land at a latitude where the same degree span covers a different number of meters, so edge lengths and area drift. **Circles, ellipses and rectangles** avoided this by reconstructing from metric properties (radius/semi-axes in meters); polygons and lines had no equivalent. That's the inconsistency reported in #172.

## Approach (measured)

Four translation methods on a tall polygon (58°–62°N) dragged ~100 km:

| Method | E–W drag | **N–S drag** | Diagonal |
|---|---|---|---|
| naive degree offset (current) | 0.00% | 3.04% | 3.04% |
| Web-Mercator offset | 0.00% | **5.98%** ❌ | 5.98% |
| Turf `transformTranslate` | 0.02% | 3.04% (no better) | 3.06% |
| **anchor-relative geodesic reconstruction** | 0.00% | **0.02%** ✅ | **0.02%** ✅ |

(area error vs. original; edge-length error tracks the same)

Only **anchor-relative geodesic reconstruction** preserves dimensions at any latitude — the direct analog of rebuilding a circle from its center + radius. Each vertex is stored as a geodesic `(distance, bearing)` offset from the drag anchor and rebuilt around the new anchor with `@turf/destination` (already a dependency, no new deps).

## Changes

- **`utils/features.ts`** — new `getTranslatedGeoJson(pristine, anchor, target)`.
- **`modes/edit/base-drag.ts`** — polygon & line dispatch to a new `moveGeodesic`. The drag loop snapshots the **pristine** geometry + anchor at drag start and applies the **total** anchor→cursor vector each tick instead of mutating the live geometry incrementally — eliminating cumulative reprojection drift over a long drag. Markers/points keep the cursor-driven path.

## Tradeoff

No lat/lng translation can look perfectly rigid in *both* globe and mercator at once (geometrically impossible). This makes the GeoJSON **dimensionally correct and projection-independent**, consistent with circle/ellipse/rectangle — which is what #172 asked for.

## Tests

- 13 new unit tests in `features-translate.spec.ts` (edges + area preserved <0.1% for N/E/diagonal; proves the naive path distorts >1% where this holds; zero-drag no-op; properties preserved). Full core unit suite: **110 passing**.
- Typecheck + lint clean.

The pro repo carries the same shared-core change (plus a pro-only `EditCopy` tweak): geoman-io/maplibre-geoman-pro#41.

Fixes #172
