### PR TITLE
test(edit): guard rectangle keeps its type through rotation (#166)

### DIFF
--- a/tests/edit/rotate.spec.ts
+++ b/tests/edit/rotate.spec.ts
@@ -19,6 +19,7 @@ import {
 import { loadGeoJson } from '@tests/utils/fixtures.ts';
 import { getScreenCoordinatesByLngLat } from '@tests/utils/shapes.ts';
 import type { LngLatTuple } from '@/main.ts';
+import { FEATURE_PROPERTY_PREFIX } from '@/core/features/constants.ts';
 import { getGeoJsonFirstPoint } from '@/utils/geojson.ts';
 import centroid from '@turf/centroid';
 import bearing from '@turf/bearing';
@@ -240,5 +241,100 @@ test('Do not move Marker, CircleMarker, TextMarker via body drag', async ({ page
       );
     }
   }
+  await page.evaluate(async () => await window.geoman.options.disableMode('edit', 'rotate'));
+});
+
+// Regression guard for #166 ("Rectangle converted into polygon after rotation").
+// Rotating a rectangle must keep it a rectangle (intrinsic shape + center/angle/
+// width/height props), not degrade into a plain polygon, and repeated rotations
+// must not accumulate dimension errors (width/height are canonical metric props,
+// rebuilt-from rather than recomputed-from geometry).
+test('#166: rectangle keeps its type, angle, and dimensions through rotation', async ({ page }) => {
+  const shapeKey = `${FEATURE_PROPERTY_PREFIX}shape`;
+  const angleKey = `${FEATURE_PROPERTY_PREFIX}angle`;
+  const widthKey = `${FEATURE_PROPERTY_PREFIX}width`;
+  const heightKey = `${FEATURE_PROPERTY_PREFIX}height`;
+
+  await enableMode(page, 'edit', 'rotate');
+
+  const features = await getRenderedFeaturesData({ page, temporary: false });
+  const rectangle = features.find((f) => f.shape === 'rectangle');
+  expect(rectangle, 'a rectangle fixture should exist').toBeTruthy();
+  if (!rectangle) return;
+
+  const startAngle = (rectangle.geoJson.properties ?? {})[angleKey];
+
+  const firstVertex = await getFirstDraggableVertex(page, rectangle);
+  expect(firstVertex, 'rectangle should expose a draggable vertex').not.toBeNull();
+  if (!firstVertex) return;
+
+  const target: LngLatTuple = [firstVertex.point[0] + 40, firstVertex.point[1] - 30];
+  await dragAndDrop(page, firstVertex.point, target as unknown as ScreenCoordinates);
+  await waitForFeatureGeoJsonUpdate({
+    feature: rectangle,
+    originalGeoJson: rectangle.geoJson,
+    page,
+  });
+  await waitForMapIdle(page);
+
+  const rotated = await waitForRenderedFeatureData({
+    page,
+    featureId: rectangle.id,
+    temporary: false,
+  });
+  expect(rotated).not.toBeNull();
+  if (!rotated) return;
+
+  const props = rotated.geoJson.properties ?? {};
+  const ring = (rotated.geoJson.geometry as { coordinates?: number[][][] }).coordinates?.[0] ?? [];
+
+  // The crux of #166: still a rectangle, not a degraded polygon.
+  expect(rotated.shape, 'shape must remain "rectangle" after rotation').toBe('rectangle');
+  expect(props[shapeKey], '__gm_shape must remain "rectangle"').toBe('rectangle');
+  // angle is stored and was changed by the rotation.
+  expect(typeof props[angleKey], 'angle must be a stored number').toBe('number');
+  expect(props[angleKey]).not.toBe(startAngle);
+  // width/height (meters) survive as intrinsic properties.
+  expect(typeof props[widthKey]).toBe('number');
+  expect(typeof props[heightKey]).toBe('number');
+  // still a closed 4-corner ring.
+  expect(ring.length).toBe(5);
+
+  // Repeated rotations must not drift the dimensions (no accumulated error).
+  const widthAfterFirst = props[widthKey] as number;
+  const heightAfterFirst = props[heightKey] as number;
+  for (let i = 0; i < 4; i++) {
+    const current = (await getRenderedFeaturesData({ page, temporary: false })).find(
+      (f) => f.id === rectangle.id,
+    );
+    if (!current) break;
+    const vertex = await getFirstDraggableVertex(page, current);
+    if (!vertex) break;
+    await dragAndDrop(page, vertex.point, [
+      vertex.point[0] + 35,
+      vertex.point[1] - 25,
+    ] as unknown as ScreenCoordinates);
+    // A small rotation can round to a near-identical geometry, so don't gate on a
+    // geojson diff here (it would flakily time out) — just let the map settle.
+    await waitForMapIdle(page);
+    await page.waitForTimeout(80);
+  }
+
+  const finalData = await waitForRenderedFeatureData({
+    page,
+    featureId: rectangle.id,
+    temporary: false,
+  });
+  const finalProps = finalData?.geoJson.properties ?? {};
+  expect(finalData?.shape, 'shape stays "rectangle" across many rotations').toBe('rectangle');
+  expect(finalProps[widthKey], 'width must not drift across rotations').toBeCloseTo(
+    widthAfterFirst,
+    6,
+  );
+  expect(finalProps[heightKey], 'height must not drift across rotations').toBeCloseTo(
+    heightAfterFirst,
+    6,
+  );
+
   await page.evaluate(async () => await window.geoman.options.disableMode('edit', 'rotate'));
 });

--- a/tests/events/rotate.spec.ts
+++ b/tests/events/rotate.spec.ts
@@ -14,8 +14,11 @@ import {
 import { getFeatureMarkersData, getRenderedFeaturesData } from '@tests/utils/features.ts';
 import { setupGeomanTest } from '@tests/utils/test-helpers.ts';
 
-// Shapes that are acceptable at rotatestart event
-// Note: Rectangle may or may not be converted to polygon at rotatestart depending on timing
+// Shapes that are acceptable at the rotatestart event. Every shape keeps its
+// intrinsic type at rotatestart — including rectangles, which since #173 are
+// rotated by updating their center/angle/width/height props and rebuilding rather
+// than being converted to a polygon (#166). The rotatestart payload must therefore
+// never momentarily report 'polygon' for a rectangle.
 const ROTATE_START_SHAPE_MAP: { [key in string]: ShapeName[] } = {
   marker: ['marker'],
   circle: ['circle'],
@@ -23,7 +26,7 @@ const ROTATE_START_SHAPE_MAP: { [key in string]: ShapeName[] } = {
   ellipse: ['ellipse'],
   text_marker: ['text_marker'],
   line: ['line'],
-  rectangle: ['rectangle', 'polygon'], // Rectangle may be converted to polygon at rotatestart
+  rectangle: ['rectangle'],
   polygon: ['polygon'],
 };
 


### PR DESCRIPTION
## Context

#166 — "Rectangle converted into polygon after rotation" — is **already fixed** by the rectangle-with-angle work: rotating a rectangle updates its `center`/`angle`/`width`/`height` props and rebuilds the geometry (`shapes.ts:rebuildRectangle`), so it stays a rectangle — with its "move one corner → two move" edit mode — instead of degrading into a plain polygon.

This PR adds the missing **regression guards** so it can't silently regress, and removes a stale test tolerance. **Test-only — no runtime changes.**

## Changes

**`tests/edit/rotate.spec.ts`** — new test `#166: rectangle keeps its type, angle, and dimensions through rotation`. The existing rotate test only compared *geometry*, so it would not catch a regression back to polygon conversion. The new test asserts shape/`__gm_shape` retention, that `angle` is stored and changed, that `width`/`height` (meters) survive, and that repeated rotations don't drift the dimensions (rebuilt from canonical props, never recomputed from geometry).

**`tests/events/rotate.spec.ts`** — tighten the `rotatestart` expectation. Rectangles no longer convert to polygon, so the `gm:rotatestart` payload must report `rectangle`, never a momentary `polygon`. Removed the stale `rectangle: ['rectangle', 'polygon']` tolerance and its "may be converted … depending on timing" comment.

## Tests
Typecheck + lint + format clean.

⚠️ **e2e not run locally:** these changes were authored and verified against the identical pro variant (where the full rotate e2e passes, 3× stable), but I could not run the rotate e2e in my local oss checkout — the dev/test server failed to initialise the map for *all* rotate specs (pre-existing ones included), an environment issue on my side, not these changes. **Please let CI confirm the e2e run.**

Fixes #166
