### PR TITLE
feat(controls): add custom control-bar buttons (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
 Visit [geoman.io/docs/maplibre](https://www.geoman.io/docs/maplibre) to get started.
 For contributor-focused internals, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
+Adding your own buttons to the control bar is documented in
+[docs/custom-controls.md](docs/custom-controls.md).
+
 ## Issues
 
 If you have support questions or want to report issues, please [create an issue](https://github.com/geoman-io/maplibre-geoman/issues) in this repository. Use this repository for issues related to both the free and pro versions of Maplibre-Geoman.
@@ -206,6 +209,39 @@ const gmOptions: GmOptionsPartial = {
 const geoman = new Geoman(map, gmOptions);
 await geoman.waitForGeomanLoaded();
 ```
+
+### Custom controls
+
+Add your own buttons to the control bar with a custom icon, tooltip and click
+handler. Each runs its own `onClick` instead of toggling a built-in mode — handy
+for toggling a map layer, exporting data, or any host-specific action.
+
+```ts
+const geoman = new Geoman(map, {
+  customControls: [
+    {
+      id: 'toggle-parcels', // unique; also used for the button id/class and removal
+      title: 'Toggle parcels layer', // tooltip (first 2 chars are the text fallback)
+      icon: '<svg viewBox="0 0 20 20">...</svg>', // optional SVG, sanitized before render
+      order: 10, // optional sort order within the custom group
+      onClick: ({ gm, control, event }) => {
+        const visible = map.getLayoutProperty('parcels', 'visibility') !== 'none';
+        map.setLayoutProperty('parcels', 'visibility', visible ? 'none' : 'visible');
+      },
+    },
+  ],
+});
+```
+
+You can also add or remove controls at run time:
+
+```ts
+geoman.control.addCustomControl({ id: 'export', title: 'Export', onClick: () => save() });
+geoman.control.removeCustomControl('export');
+```
+
+See [docs/custom-controls.md](docs/custom-controls.md) for the full reference and
+a live example in the dev app (`apps/dev/common.ts`).
 
 ## Contributing
 

--- a/apps/dev/common.ts
+++ b/apps/dev/common.ts
@@ -1,5 +1,6 @@
 import { layerStyles } from './styles/layer-styles.ts';
 import { Geoman, IS_PRO } from '@/main.ts';
+import { getGeoJsonBounds } from '@/utils/geojson.ts';
 import type { AnyMapInstance, MapInstanceWithGeoman } from '@/types/map/index.ts';
 import type { GmOptionsData } from '@/types/options.ts';
 import log from 'loglevel';
@@ -39,6 +40,29 @@ export function createGmOptions(): PartialDeep<GmOptionsData> {
         },
       },
     },
+    // Demo: host-defined control-bar buttons (issue #205). Each runs its own
+    // onClick handler instead of toggling a built-in mode. A control can also be
+    // added/removed at run time via geoman.control.addCustomControl() — see the
+    // toggle demo in setupDevEnvironment(). Docs: README "Custom controls".
+    customControls: [
+      {
+        id: 'zoom-to-features',
+        title: 'Zoom to features',
+        order: 10,
+        icon: `
+          <svg viewBox="0 0 20 20" width="16" height="16" fill="none"
+               stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+            <circle cx="9" cy="9" r="5.5" />
+            <line x1="13.5" y1="13.5" x2="18" y2="18" />
+          </svg>`,
+        onClick: ({ gm }) => {
+          const geoJson = gm.features.getAll();
+          if (geoJson.features.length) {
+            gm.mapAdapter.fitBounds(getGeoJsonBounds(geoJson), { padding: 40 });
+          }
+        },
+      },
+    ],
   };
 }
 
@@ -197,7 +221,29 @@ export function setupDevEnvironment(geoman: Geoman, map: DevMapInstance): void {
   window.customData.map = map as unknown as MapInstanceWithGeoman;
 
   mountPanels(geoman, map);
+  addDemoToggleControl(geoman);
 
   log.debug(`Geoman version: "${IS_PRO ? 'pro' : 'free'}"`);
   log.debug('Dev panels mounted');
+}
+
+// Demo of the runtime custom-control API (issue #205): a toggle button that
+// re-adds itself with a flipped `active` (pressed) state on each click. Adding a
+// control with an existing id replaces the previous one in place.
+function addDemoToggleControl(geoman: Geoman): void {
+  let active = false;
+  const render = () => {
+    geoman.control.addCustomControl({
+      id: 'demo-toggle',
+      title: active ? 'Demo toggle (on)' : 'Demo toggle (off)',
+      order: 20,
+      active,
+      onClick: () => {
+        active = !active;
+        log.info(`Custom control "demo-toggle" is now ${active ? 'on' : 'off'}`);
+        render();
+      },
+    });
+  };
+  render();
 }

--- a/docs/custom-controls.md
+++ b/docs/custom-controls.md
@@ -1,0 +1,109 @@
+# Custom controls
+
+Custom controls are host-defined buttons rendered as an extra group below
+Geoman's built-in control bar. Unlike the built-in controls (which toggle a
+draw/edit/helper mode), a custom control runs an arbitrary `onClick` handler — so
+you can wire the control bar up to host actions like toggling a map layer,
+exporting data, opening a panel, or zooming to features.
+
+> Implements the request in
+> [geoman-io/maplibre-geoman#205](https://github.com/geoman-io/maplibre-geoman/issues/205).
+
+## Quick start
+
+Pass `customControls` when you create Geoman:
+
+```ts
+const geoman = new Geoman(map, {
+  customControls: [
+    {
+      id: 'toggle-parcels',
+      title: 'Toggle parcels layer',
+      icon: '<svg viewBox="0 0 20 20">...</svg>',
+      order: 10,
+      onClick: ({ gm, control, event }) => {
+        const hidden = map.getLayoutProperty('parcels', 'visibility') === 'none';
+        map.setLayoutProperty('parcels', 'visibility', hidden ? 'visible' : 'none');
+      },
+    },
+  ],
+});
+```
+
+The button appears in a `group-custom` group at the bottom of the control bar,
+using the same styling (`controlsStyles`) as the built-in buttons.
+
+## The `CustomControl` shape
+
+| Field     | Type                             | Required | Notes                                                                                |
+| --------- | -------------------------------- | :------: | ------------------------------------------------------------------------------------ |
+| `id`      | `string`                         |   yes    | Unique. Used for the button's DOM id (`id_custom_<id>`) / class and for removal.     |
+| `onClick` | `(ctx) => void \| Promise<void>` |   yes    | Click handler. `ctx` is `{ gm, control, event }`. Async handlers are awaited.        |
+| `title`   | `string`                         |    no    | Tooltip. When no `icon` is set, the first two characters render as the button label. |
+| `icon`    | `string \| null`                 |    no    | Raw SVG markup; **sanitized with DOMPurify** before render.                          |
+| `order`   | `number`                         |    no    | Sort order within the custom group (lower first). Ties keep insertion order.         |
+| `active`  | `boolean`                        |    no    | Controlled pressed state — adds the `active` class. You own toggling it (see below). |
+
+The click context:
+
+```ts
+interface CustomControlClickContext {
+  gm: Geoman; // the Geoman instance
+  control: CustomControl; // the control that was clicked
+  event: MouseEvent; // the DOM click event
+}
+```
+
+`CustomControl` and `CustomControlClickContext` are exported from the package, so
+you can type your control definitions.
+
+## Runtime API
+
+Controls can be added or removed after init via `geoman.control`:
+
+```ts
+geoman.control.addCustomControl({
+  id: 'export',
+  title: 'Export GeoJSON',
+  onClick: ({ gm }) => console.log(gm.features.exportGeoJson()),
+});
+
+geoman.control.removeCustomControl('export');
+```
+
+`addCustomControl` is also an upsert: adding a control whose `id` already exists
+replaces it in place. This is the idiom for a toggle button — re-add it with a
+flipped `active` from inside its own handler:
+
+```ts
+let on = false;
+const renderToggle = () => {
+  geoman.control.addCustomControl({
+    id: 'demo-toggle',
+    title: on ? 'On' : 'Off',
+    active: on,
+    onClick: () => {
+      on = !on;
+      renderToggle();
+    },
+  });
+};
+renderToggle();
+```
+
+## Notes
+
+- Custom controls are **not** subject to the selection-requirement gating that
+  applies to built-in edit tools — they are always clickable. If you need a
+  control disabled in some state, manage that yourself (e.g. no-op in `onClick`).
+- Handler errors are caught and logged (via `loglevel`) so a throwing handler
+  never breaks the control bar.
+- The control bar is only rendered when `settings.useControlsUi` is `true`
+  (the default).
+
+## Live example
+
+The dev app wires up two demo controls in
+[`apps/dev/common.ts`](../apps/dev/common.ts): a declarative "Zoom to features"
+button (in `createGmOptions()`) and a runtime toggle button (in
+`setupDevEnvironment()`). Run it with `pnpm run dev:maplibre`.

--- a/packages/core/src/core/controls/components/controls-store.ts
+++ b/packages/core/src/core/controls/components/controls-store.ts
@@ -1,16 +1,19 @@
 import { systemControls } from '@/core/controls/defaults.ts';
 import { getDefaultOptions } from '@/core/options/defaults/index.ts';
-import type { SystemControls } from '@/types/controls.ts';
+import type { CustomControl, SystemControls } from '@/types/controls.ts';
 import type { GmOptionsData } from '@/types/options.ts';
 import { cloneDeep } from 'lodash-es';
 import { writable } from 'svelte/store';
 
 const initialState: {
   controls: SystemControls;
+  // host-defined buttons rendered as an extra group below the built-in controls
+  customControls: Array<CustomControl>;
   options: GmOptionsData['controls'];
   settings: GmOptionsData['settings'];
 } = {
   controls: cloneDeep(systemControls),
+  customControls: [],
   options: getDefaultOptions().controls,
   settings: getDefaultOptions().settings,
 };

--- a/packages/core/src/core/controls/components/custom-control.svelte
+++ b/packages/core/src/core/controls/components/custom-control.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { controlsStore } from '@/core/controls/components/controls-store.ts';
+  import type { CustomControl } from '@/types/controls.ts';
+  import type { Geoman } from '@/main.ts';
+  import DOMPurify from 'dompurify';
+  import log from 'loglevel';
+  import { getContext } from 'svelte';
+
+  const { control }: { control: CustomControl } = $props();
+
+  const gm: Geoman = getContext('gm');
+  const sanitizedSvg = $derived(control.icon ? DOMPurify.sanitize(control.icon.trim()) : null);
+
+  const handleClick = async (event: MouseEvent) => {
+    try {
+      await control.onClick({ gm, control, event });
+    } catch (error) {
+      log.error(`Custom control "${control.id}" onClick handler failed`, error);
+    }
+  };
+</script>
+
+<div class={$controlsStore.settings.controlsStyles.controlContainerClass}>
+  <button
+    type="button"
+    id={`id_custom_${control.id}`}
+    class={`${$controlsStore.settings.controlsStyles.controlButtonClass} custom-${control.id}`}
+    class:active={control.active}
+    title={control.title}
+    onclick={handleClick}>
+    {#if sanitizedSvg}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized with DOMPurify -->
+      {@html sanitizedSvg}
+    {:else if control.title}
+      {control.title.slice(0, 2)}
+    {:else}
+      {control.id.slice(0, 2)}
+    {/if}
+  </button>
+</div>
+
+<style></style>

--- a/packages/core/src/core/controls/components/gm-controls.svelte
+++ b/packages/core/src/core/controls/components/gm-controls.svelte
@@ -52,10 +52,15 @@
       .map(({ key, options }) => [key, options] as [string, ControlOptions]);
   };
 
-  // Sort by `order` (undefined sinks to the end); a stable sort keeps insertion
-  // order for ties. Copy first so the store array is not mutated in place.
+  // Sort by `order` (undefined sinks to the end); ties return 0 so the stable
+  // native sort keeps insertion order. Copy first so the store array is not
+  // mutated in place.
   const sortCustomControls = (controls: Array<CustomControl>): Array<CustomControl> =>
-    [...controls].sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity));
+    [...controls].sort((a, b) => {
+      const orderA = a.order ?? Infinity;
+      const orderB = b.order ?? Infinity;
+      return orderA === orderB ? 0 : orderA - orderB;
+    });
 </script>
 
 <div class="gm-reactive-controls">

--- a/packages/core/src/core/controls/components/gm-controls.svelte
+++ b/packages/core/src/core/controls/components/gm-controls.svelte
@@ -2,9 +2,10 @@
   import caretDown from '@/assets/images/controls2/caret-down.svg';
   import caretUp from '@/assets/images/controls2/caret-up.svg';
   import ActionControl from '@/core/controls/components/action-control.svelte';
+  import CustomControlButton from '@/core/controls/components/custom-control.svelte';
   import { controlsStore } from '@/core/controls/components/controls-store.ts';
   import type { ControlOptions, ModeType } from '@/types/options.ts';
-  import type { GenericSystemControls, ModeName } from '@/types/controls.ts';
+  import type { CustomControl, GenericSystemControls, ModeName } from '@/types/controls.ts';
   import DOMPurify from 'dompurify';
 
   // const gm: Geoman = getContext('gm');
@@ -50,6 +51,11 @@
       })
       .map(({ key, options }) => [key, options] as [string, ControlOptions]);
   };
+
+  // Sort by `order` (undefined sinks to the end); a stable sort keeps insertion
+  // order for ties. Copy first so the store array is not mutated in place.
+  const sortCustomControls = (controls: Array<CustomControl>): Array<CustomControl> =>
+    [...controls].sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity));
 </script>
 
 <div class="gm-reactive-controls">
@@ -78,6 +84,13 @@
           </div>
         {/if}
       {/each}
+      {#if $controlsStore.customControls.length}
+        <div class={`${controlsStyles.controlGroupClass} group-custom`}>
+          {#each sortCustomControls($controlsStore.customControls) as control (control.id)}
+            <CustomControlButton control={control} />
+          {/each}
+        </div>
+      {/if}
     </div>
   {/if}
 </div>

--- a/packages/core/src/core/controls/index.ts
+++ b/packages/core/src/core/controls/index.ts
@@ -4,6 +4,7 @@ import GmReactiveControls from '@/core/controls/components/gm-controls.svelte';
 import { systemControls } from '@/core/controls/defaults.ts';
 import { BaseControl } from '@/core/map/base/control.ts';
 import type {
+  CustomControl,
   ModeName,
   SystemControls,
   GenericSystemControl,
@@ -107,9 +108,33 @@ export default class GMControl extends BaseControl {
   updateReactivePanel() {
     controlsStore.update(() => ({
       controls: this.controls,
+      customControls: this.gm.options.customControls,
       options: this.gm.options.controls,
       settings: this.gm.options.settings,
     }));
+  }
+
+  /**
+   * Add (or replace, by id) a host-defined control-bar button at run time.
+   * Replacing keeps the control's existing position. Re-renders the control
+   * panel so the change appears immediately.
+   */
+  addCustomControl(control: CustomControl) {
+    const current = this.gm.options.customControls;
+    const index = current.findIndex((existing) => existing.id === control.id);
+    this.gm.options.customControls =
+      index === -1
+        ? [...current, control]
+        : current.map((existing) => (existing.id === control.id ? control : existing));
+    this.updateReactivePanel();
+  }
+
+  /** Remove a previously added custom control by id. */
+  removeCustomControl(id: string) {
+    this.gm.options.customControls = this.gm.options.customControls.filter(
+      (existing) => existing.id !== id,
+    );
+    this.updateReactivePanel();
   }
 
   createHtmlContainer() {

--- a/packages/core/src/core/controls/index.ts
+++ b/packages/core/src/core/controls/index.ts
@@ -122,10 +122,13 @@ export default class GMControl extends BaseControl {
   addCustomControl(control: CustomControl) {
     const current = this.gm.options.customControls;
     const index = current.findIndex((existing) => existing.id === control.id);
-    this.gm.options.customControls =
-      index === -1
-        ? [...current, control]
-        : current.map((existing) => (existing.id === control.id ? control : existing));
+    if (index === -1) {
+      this.gm.options.customControls = [...current, control];
+    } else {
+      const next = [...current];
+      next[index] = control;
+      this.gm.options.customControls = next;
+    }
     this.updateReactivePanel();
   }
 

--- a/packages/core/src/core/options/index.ts
+++ b/packages/core/src/core/options/index.ts
@@ -3,7 +3,7 @@ import { getDefaultOptions, trackDefaultUiEnabledState } from '@/core/options/de
 import { mergeByTypeCustomizer } from '@/core/options/utils.ts';
 import type { Geoman } from '@/main.ts';
 import { DRAW_MODES, EDIT_MODES, HELPER_MODES } from '@/modes/constants.ts';
-import type { ModeName } from '@/types/controls.ts';
+import type { CustomControl, ModeName } from '@/types/controls.ts';
 import type { GmControlSwitchEvent } from '@/types/events/control.ts';
 import type { GmBaseModeEvent, ModeAction } from '@/types/events/mode.ts';
 import type {
@@ -26,6 +26,9 @@ export class GmOptions {
   settings: GmOptionsData['settings'];
   controls: GmOptionsData['controls'];
   layerStyles: GmOptionsData['layerStyles'];
+  // kept by reference (outside the merge) so the host's `onClick` functions
+  // and array identity survive the deep-merge/array-merge customizer
+  customControls: Array<CustomControl>;
 
   constructor(gm: Geoman, inputOptions: PartialDeep<GmOptionsData>) {
     this.gm = gm;
@@ -33,10 +36,15 @@ export class GmOptions {
     this.settings = options.settings;
     this.controls = options.controls;
     this.layerStyles = options.layerStyles;
+    this.customControls = (inputOptions.customControls as Array<CustomControl>) ?? [];
   }
 
   getMergedOptions(options: PartialDeep<GmOptionsData> = {}): GmOptionsData {
     const defaultOptions = getDefaultOptions();
+    // `customControls` is held separately (see field above); keep it out of the
+    // deep merge so its handler functions are not stripped and the
+    // array-merge customizer does not warn on it
+    const { customControls: _customControls, ...mergeableOptions } = options;
 
     if (typeof options.settings?.controlsUiEnabledByDefault === 'boolean') {
       defaultOptions.settings.controlsUiEnabledByDefault =
@@ -45,7 +53,7 @@ export class GmOptions {
 
     trackDefaultUiEnabledState(defaultOptions);
 
-    return mergeWith(defaultOptions, options, mergeByTypeCustomizer);
+    return mergeWith(defaultOptions, mergeableOptions, mergeByTypeCustomizer);
   }
 
   async enableMode(modeType: ModeType, modeName: ModeName) {

--- a/packages/core/src/types/controls.ts
+++ b/packages/core/src/types/controls.ts
@@ -19,7 +19,11 @@ export interface CustomControlClickContext {
  * option or at run time through `gm.control.addCustomControl()`.
  */
 export interface CustomControl {
-  /** unique id; used for the button's id/class and for removal */
+  /**
+   * unique id; used for the button's DOM id (`id_custom_<id>`), class
+   * (`custom-<id>`) and for removal. Use a valid CSS identifier (no spaces or
+   * special characters) so the generated id/class and selectors stay well-formed.
+   */
   id: string;
   /** tooltip text; its first two chars are the text fallback when no icon is set */
   title?: string;

--- a/packages/core/src/types/controls.ts
+++ b/packages/core/src/types/controls.ts
@@ -6,6 +6,33 @@ export interface ControlSettings {
   enabledBy?: Array<ModeName>;
 }
 
+/** Context passed to a custom control's click handler. */
+export interface CustomControlClickContext {
+  gm: import('@/main.ts').Geoman;
+  control: CustomControl;
+  event: MouseEvent;
+}
+
+/**
+ * A host-defined control-bar button that runs an arbitrary handler on click
+ * instead of toggling a built-in mode. Provide these via the `customControls`
+ * option or at run time through `gm.control.addCustomControl()`.
+ */
+export interface CustomControl {
+  /** unique id; used for the button's id/class and for removal */
+  id: string;
+  /** tooltip text; its first two chars are the text fallback when no icon is set */
+  title?: string;
+  /** raw SVG markup for the icon (sanitized with DOMPurify before render) */
+  icon?: string | null;
+  /** invoked when the button is clicked */
+  onClick: (context: CustomControlClickContext) => void | Promise<void>;
+  /** sort order within the custom-control group (lower comes first) */
+  order?: number;
+  /** controlled active/pressed state for toggle-style buttons */
+  active?: boolean;
+}
+
 export interface SystemControl<AT extends ActionType, Mode> {
   readonly type: AT;
   readonly targetMode: Mode;

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -1,5 +1,5 @@
 import defaultLayerStyles from '@/core/options/layers/style.ts';
-import type { ModeName } from '@/types/controls.ts';
+import type { CustomControl, ModeName } from '@/types/controls.ts';
 import type { BaseControlsPosition } from '@/types/map/index.ts';
 import type {
   ActionOptions,
@@ -72,6 +72,13 @@ export type GmOptionsData = {
     edit: { [key in EditModeName]?: ControlOptions };
     helper: { [key in HelperModeName]?: ControlOptions };
   };
+  /**
+   * Host-defined control-bar buttons rendered as an extra group below the
+   * built-in controls. Each runs its own `onClick` handler instead of toggling
+   * a mode. Can also be managed at run time via
+   * `gm.control.addCustomControl()` / `removeCustomControl()`.
+   */
+  customControls?: Array<CustomControl>;
 };
 export type GmOptionsPartial = PartialDeep<GmOptionsData>;
 export type GenericControlsOptions = {

--- a/scripts/api-surface/mapbox.json
+++ b/scripts/api-surface/mapbox.json
@@ -25,6 +25,8 @@
   "reexport-type:ControlStyles",
   "reexport-type:CoordinateIndices",
   "reexport-type:CursorType",
+  "reexport-type:CustomControl",
+  "reexport-type:CustomControlClickContext",
   "reexport-type:DomMarkerData",
   "reexport-type:DrawModeName",
   "reexport-type:EdgeMarkerData",

--- a/scripts/api-surface/maplibre.json
+++ b/scripts/api-surface/maplibre.json
@@ -25,6 +25,8 @@
   "reexport-type:ControlStyles",
   "reexport-type:CoordinateIndices",
   "reexport-type:CursorType",
+  "reexport-type:CustomControl",
+  "reexport-type:CustomControlClickContext",
   "reexport-type:DomMarkerData",
   "reexport-type:DrawModeName",
   "reexport-type:EdgeMarkerData",

--- a/tests/controls/custom-controls.spec.ts
+++ b/tests/controls/custom-controls.spec.ts
@@ -1,0 +1,114 @@
+import test, { expect, type Page } from '@playwright/test';
+import { waitForGeoman } from '@tests/utils/basic.ts';
+
+// Custom controls are host-defined buttons rendered as an extra control group.
+// They run an arbitrary `onClick` handler instead of toggling a built-in mode,
+// and can be managed at run time via gm.control.addCustomControl()/removeCustomControl().
+test.describe('Custom controls', () => {
+  let page: Page;
+
+  test.beforeEach(async ({ page: p }) => {
+    page = p;
+    await page.goto('/');
+    await waitForGeoman(page);
+  });
+
+  test('renders a custom control and fires its onClick handler', async () => {
+    await page.evaluate(() => {
+      window.customData = { rawEventResults: { clicks: 0 } };
+      window.geoman.control.addCustomControl({
+        id: 'unit-toggle',
+        title: 'Toggle layer',
+        onClick: () => {
+          const data = window.customData.rawEventResults as { clicks: number };
+          data.clicks += 1;
+        },
+      });
+    });
+
+    const button = page.locator('#id_custom_unit-toggle');
+    await expect(button).toBeVisible();
+    // no icon provided -> first two chars of the title are the text fallback
+    await expect(button).toHaveText('To');
+    await expect(button).toHaveAttribute('title', 'Toggle layer');
+
+    await button.click();
+    await button.click();
+
+    const clicks = await page.evaluate(
+      () => (window.customData.rawEventResults as { clicks: number }).clicks,
+    );
+    expect(clicks).toBe(2);
+  });
+
+  test('passes the geoman instance and control to the handler', async () => {
+    await page.evaluate(() => {
+      window.customData = {};
+      window.geoman.control.addCustomControl({
+        id: 'unit-context',
+        title: 'Ctx',
+        onClick: ({ gm, control }) => {
+          window.customData.rawEventResults = {
+            hasGm: gm === window.geoman,
+            controlId: control.id,
+          };
+        },
+      });
+    });
+
+    // auto-waits for the Svelte store update to render the button before clicking
+    await page.locator('#id_custom_unit-context').click();
+
+    const result = await page.evaluate(() => window.customData.rawEventResults);
+    expect(result).toEqual({ hasGm: true, controlId: 'unit-context' });
+  });
+
+  test('renders the icon when provided and sorts by order', async () => {
+    await page.evaluate(() => {
+      window.geoman.control.addCustomControl({
+        id: 'second',
+        title: 'Second',
+        order: 20,
+        onClick: () => {},
+      });
+      window.geoman.control.addCustomControl({
+        id: 'first',
+        title: 'First',
+        order: 10,
+        icon: '<svg viewBox="0 0 10 10"><rect width="10" height="10" /></svg>',
+        onClick: () => {},
+      });
+    });
+
+    const group = page.locator('.group-custom');
+    await expect(group).toBeVisible();
+    // lower `order` comes first regardless of insertion order
+    const ids = await group.locator('button').evaluateAll((els) => els.map((el) => el.id));
+    expect(ids).toEqual(['id_custom_first', 'id_custom_second']);
+
+    // icon control renders the (sanitized) svg rather than a text fallback
+    await expect(page.locator('#id_custom_first svg')).toBeVisible();
+  });
+
+  test('removeCustomControl removes the button', async () => {
+    await page.evaluate(() => {
+      window.geoman.control.addCustomControl({ id: 'removable', title: 'Rm', onClick: () => {} });
+    });
+    await expect(page.locator('#id_custom_removable')).toBeVisible();
+
+    await page.evaluate(() => {
+      window.geoman.control.removeCustomControl('removable');
+    });
+    await expect(page.locator('#id_custom_removable')).toHaveCount(0);
+  });
+
+  test('adding a control with an existing id replaces it', async () => {
+    await page.evaluate(() => {
+      window.geoman.control.addCustomControl({ id: 'dup', title: 'Old', onClick: () => {} });
+      window.geoman.control.addCustomControl({ id: 'dup', title: 'New', onClick: () => {} });
+    });
+
+    await expect(page.locator('#id_custom_dup')).toHaveCount(1);
+    await expect(page.locator('#id_custom_dup')).toHaveAttribute('title', 'New');
+  });
+});

--- a/tests/controls/custom-controls.spec.ts
+++ b/tests/controls/custom-controls.spec.ts
@@ -111,4 +111,56 @@ test.describe('Custom controls', () => {
     await expect(page.locator('#id_custom_dup')).toHaveCount(1);
     await expect(page.locator('#id_custom_dup')).toHaveAttribute('title', 'New');
   });
+
+  test('renders controls passed declaratively at init and keeps the handler through the options merge', async () => {
+    // Reinit Geoman with `customControls` in the init options. This exercises the
+    // declarative path: the handler must survive the options deep-merge (it is
+    // held by reference outside the merge) for the click below to register.
+    await page.evaluate(async () => {
+      await window.geoman.destroy({ removeSources: true });
+      window.customData = { rawEventResults: { clicks: 0 } };
+      const geoman = new window.GeomanClass(window.mapInstance, {
+        customControls: [
+          {
+            id: 'init-decl',
+            title: 'Declared',
+            icon: '<svg viewBox="0 0 10 10"><rect width="10" height="10" /></svg>',
+            onClick: () => {
+              const data = window.customData.rawEventResults as { clicks: number };
+              data.clicks += 1;
+            },
+          },
+        ],
+      });
+      window.geoman = geoman;
+    });
+
+    await waitForGeoman(page);
+
+    const button = page.locator('#id_custom_init-decl');
+    await expect(button).toBeVisible();
+    await expect(button).toHaveAttribute('title', 'Declared');
+    // icon renders -> the declarative control reached the component intact
+    await expect(page.locator('#id_custom_init-decl svg')).toBeVisible();
+
+    // clicking proves the onClick function was not stripped by the deep-merge
+    await button.click();
+    const clicks = await page.evaluate(
+      () => (window.customData.rawEventResults as { clicks: number }).clicks,
+    );
+    expect(clicks).toBe(1);
+  });
+
+  test('keeps insertion order for controls without an explicit order', async () => {
+    await page.evaluate(() => {
+      window.geoman.control.addCustomControl({ id: 'alpha', title: 'A', onClick: () => {} });
+      window.geoman.control.addCustomControl({ id: 'beta', title: 'B', onClick: () => {} });
+      window.geoman.control.addCustomControl({ id: 'gamma', title: 'C', onClick: () => {} });
+    });
+
+    const ids = await page
+      .locator('.group-custom button')
+      .evaluateAll((els) => els.map((el) => el.id));
+    expect(ids).toEqual(['id_custom_alpha', 'id_custom_beta', 'id_custom_gamma']);
+  });
 });


### PR DESCRIPTION
## What

Adds **custom control-bar buttons** so hosts can put their own buttons in the Geoman control bar with a custom **icon, tooltip, and `onClick` handler** — instead of being limited to the built-in draw/edit/helper mode toggles.

Ported from the pro repo ([maplibre-geoman-pro#44](https://github.com/geoman-io/maplibre-geoman-pro/pull/44)). The feature lives entirely in shared `packages/core`, so it belongs in the free package too. Closes #205.

## API

**Declarative (init option):**
```ts
new Geoman(map, {
  customControls: [
    {
      id: 'toggle-parcels',
      title: 'Toggle parcels layer', // tooltip; first 2 chars are the text fallback
      icon: '<svg ...>...</svg>',     // optional, sanitized with DOMPurify
      order: 10,                      // optional sort within the custom group
      onClick: ({ gm, control, event }) => { /* ... */ },
    },
  ],
});
```

**Runtime:**
```ts
geoman.control.addCustomControl({ id: 'export', title: 'Export', onClick: () => save() });
geoman.control.removeCustomControl('export');
```

## How it works

- Rendered as a `group-custom` group below the built-in controls, sorted by `order`, reusing the existing `controlsStyles`.
- `addCustomControl` is an upsert by `id` and **preserves position** (so the toggle idiom — re-add with flipped `active` on each click — doesn't shuffle buttons).
- `customControls` is held **outside the options deep-merge** so the host's handler functions aren't stripped and the layer-array merge customizer doesn't warn.
- Handler errors are caught and logged via `loglevel`; icons sanitized with DOMPurify.
- Exports `CustomControl` / `CustomControlClickContext` types (api-surface baselines updated for both maplibre and mapbox).

## Porting notes (vs pro PR #44)

The OSS `packages/core` has diverged from pro (no `selectionStatus` / `ControlsStoreState` infrastructure, simpler `getMergedOptions`), so the change was adapted rather than cherry-picked:
- `controls-store.ts` uses OSS's inline-typed store state.
- The dev-app demo's declarative button uses `gm.mapAdapter.fitBounds(getGeoJsonBounds(...))` in place of the **pro-only** `gm.zoomToFeatures()`.

## Tests & docs

- Playwright: `tests/controls/custom-controls.spec.ts` (render + fallback text/tooltip, handler context, icon + `order` sorting, remove, upsert-by-id).
- Docs: `docs/custom-controls.md` + a README "Custom controls" section.
- Demo: `apps/dev/common.ts` (declarative "Zoom to features" button + a runtime toggle button).

## Validation

Locally green: `oxfmt` · `oxlint` · `typecheck:all` (incl. `apps/dev`) · `api:check` · `test:unit` (97) · both package builds.

⚠️ The Playwright e2e suite was **not run locally** — the base map fails to initialize in this sandbox (a pre-existing environment limitation that fails existing specs too, not specific to this change). The new spec is a faithful port and should run in CI.