### PR TITLE
test(e2e): configurable test-server port + strict health check

### DIFF
--- a/packages/mapbox/package.json
+++ b/packages/mapbox/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "dev": "vite ../.. --config vite.config.ts",
     "build": "rimraf dist && vite build --config vite.config.ts && pnpm run build:types && node ../../scripts/verify-variant-bundle.mjs mapbox dist",
-    "testserver": "vite ../.. --config vite.config.ts --host 127.0.0.1 --port 4001 --mode test",
+    "testserver": "vite ../.. --config vite.config.ts --host 127.0.0.1 --port 4001 --strictPort --mode test",
     "build:types": "tsc -p tsconfig.types.json --emitDeclarationOnly && tsc-alias -p tsconfig.types.json && rollup -c rollup.config.dts.js && node ../../scripts/verify-variant-types.mjs mapbox dist/mapbox-geoman.d.ts && rimraf dist/types",
     "ts": "tsc --noEmit -p ../../tsconfig.mapbox.json",
     "lint": "oxlint src",

--- a/packages/maplibre/package.json
+++ b/packages/maplibre/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "dev": "vite ../.. --config vite.config.ts",
     "build": "rimraf dist && vite build --config vite.config.ts && pnpm run build:types && node ../../scripts/verify-variant-bundle.mjs maplibre dist",
-    "testserver": "vite ../.. --config vite.config.ts --host 127.0.0.1 --port 4000 --mode test",
+    "testserver": "vite ../.. --config vite.config.ts --host 127.0.0.1 --port 4000 --strictPort --mode test",
     "build:types": "tsc -p tsconfig.types.json --emitDeclarationOnly && tsc-alias -p tsconfig.types.json && rollup -c rollup.config.dts.js && node ../../scripts/verify-variant-types.mjs maplibre dist/maplibre-geoman.d.ts && rimraf dist/types",
     "ts": "tsc --noEmit -p ../../tsconfig.maplibre.json",
     "lint": "oxlint src",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { testServerHost, testServerPort, testServerUrl } from './tests/server-config.ts';
 
 const playwrightVariantRaw = process.env.PLAYWRIGHT_VARIANT;
 if (!playwrightVariantRaw || !['maplibre', 'mapbox'].includes(playwrightVariantRaw)) {
@@ -8,9 +9,16 @@ if (!playwrightVariantRaw || !['maplibre', 'mapbox'].includes(playwrightVariantR
 }
 
 const playwrightVariant = playwrightVariantRaw as 'maplibre' | 'mapbox';
+const variantPackage =
+  playwrightVariant === 'mapbox' ? 'mapbox-geoman-free' : 'maplibre-geoman-free';
+
+// Port/host/url come from tests/server-config.ts (shared with the globalSetup
+// health check). Launch the variant's Vite test server on that port.
+// `--strictPort` makes Vite fail loudly if the port is already taken instead of
+// drifting to another port (which would no longer match `testServerUrl`).
 const testServerCommand =
-  playwrightVariant === 'mapbox' ? 'pnpm run testserver:mapbox' : 'pnpm run testserver:maplibre';
-const testServerPort = playwrightVariant === 'mapbox' ? 4001 : 4000;
+  `pnpm --filter @geoman-io/${variantPackage} exec vite ../.. --config vite.config.ts ` +
+  `--host ${testServerHost} --port ${testServerPort} --strictPort --mode test`;
 
 /**
  * Read environment variables from file.
@@ -24,6 +32,9 @@ const testServerPort = playwrightVariant === 'mapbox' ? 4001 : 4000;
  */
 export default defineConfig({
   testDir: './tests',
+  /* Verify the test server is actually the Geoman dev app before running (guards
+   * against a foreign process being reused on the port). */
+  globalSetup: './tests/global-setup.ts',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Timeout for a test - increased for CI */
@@ -42,7 +53,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: `http://127.0.0.1:${testServerPort}/`,
+    baseURL: testServerUrl,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     /* Navigation timeout - increased for CI */
@@ -94,10 +105,13 @@ export default defineConfig({
     // },
   ],
 
-  /* Run the local dev server before starting the tests */
+  /* Run the local dev server before starting the tests. Locally an existing
+   * server on the port is reused for speed; globalSetup then verifies it is
+   * actually the Geoman app, so a foreign server fails fast with a clear error
+   * instead of every test failing with "Geoman failed to initialize". */
   webServer: {
     command: testServerCommand,
-    url: `http://127.0.0.1:${testServerPort}/`,
+    url: testServerUrl,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,28 @@
+import { testServerUrl } from './server-config.ts';
+
+// Strict health check: confirm the configured test-server URL is actually
+// serving the Geoman dev app before any test runs. Playwright's webServer reuse
+// only checks that *something* answers on the port, so a foreign dev server
+// (e.g. another project on the same port) would otherwise be reused silently and
+// every test would fail with a confusing "Geoman failed to initialize".
+export default async function globalSetup(): Promise<void> {
+  let body: string;
+  try {
+    const response = await fetch(testServerUrl);
+    body = await response.text();
+  } catch (error) {
+    throw new Error(
+      `Test server health check failed: could not reach ${testServerUrl} (${String(error)}).`,
+    );
+  }
+
+  // Markers rendered by the Geoman dev app entry HTML (apps/dev + index.html).
+  const isGeomanApp = body.includes('id="dev-map"') && body.includes('Geoman plugin');
+  if (!isGeomanApp) {
+    throw new Error(
+      `Test server health check failed: ${testServerUrl} did not serve the Geoman dev app — ` +
+        `another process is likely using the port. Free it, or set PLAYWRIGHT_TEST_PORT ` +
+        `to an unused port (e.g. PLAYWRIGHT_TEST_PORT=4100).`,
+    );
+  }
+}

--- a/tests/server-config.ts
+++ b/tests/server-config.ts
@@ -1,0 +1,14 @@
+// Single source of truth for the Playwright test-server location, shared by
+// playwright.config.ts and the globalSetup health check so they can never drift.
+// The port is configurable via PLAYWRIGHT_TEST_PORT, defaulting per variant so
+// the maplibre and mapbox runs don't collide.
+const variant = process.env.PLAYWRIGHT_VARIANT === 'mapbox' ? 'mapbox' : 'maplibre';
+
+export const testServerHost = '127.0.0.1';
+
+const defaultPort = variant === 'mapbox' ? 4001 : 4000;
+const parsedPort = Number.parseInt(process.env.PLAYWRIGHT_TEST_PORT ?? '', 10);
+export const testServerPort =
+  Number.isInteger(parsedPort) && parsedPort > 0 ? parsedPort : defaultPort;
+
+export const testServerUrl = `http://${testServerHost}:${testServerPort}/`;


### PR DESCRIPTION
## Why

When another process is already listening on the Playwright test-server port (e.g. an unrelated local dev server), `reuseExistingServer` silently reuses it. Every spec then fails with a confusing `Geoman failed to initialize` because the wrong app is served. This actually happened during local testing (a Phoenix app on port 4000), and the failure mode gives no hint at the real cause.

## What

- **Configurable port** via `PLAYWRIGHT_TEST_PORT`, defaulting per variant (`4000` maplibre / `4001` mapbox). Port/host/url are computed once in `tests/server-config.ts` and shared by both the config and the health check so they can't drift.
- **`--strictPort`** on the webServer command (and the manual `testserver` scripts): Vite now fails loudly on a port collision instead of silently drifting to another port that no longer matches the URL Playwright waits on.
- **Strict health check** (`tests/global-setup.ts`): before any test runs, fetch the server URL and verify it actually serves the Geoman dev app. A foreign server now fails fast with an actionable message:

  ```
  Test server health check failed: http://127.0.0.1:4000/ did not serve the Geoman dev app —
  another process is likely using the port. Free it, or set PLAYWRIGHT_TEST_PORT to an unused
  port (e.g. PLAYWRIGHT_TEST_PORT=4100).
  ```

## Verification

- Normal flow (port free): existing specs pass through the new webServer command + globalSetup. ✓
- Foreign app on the port: globalSetup fails fast with the clear message above (verified by pointing `PLAYWRIGHT_TEST_PORT` at a non-Geoman server). ✓
- Port collision with `--strictPort`: Vite exits with `Port X is already in use` instead of drifting. ✓
- `oxfmt` · `oxlint` · `typecheck` all green.

## Notes

- CI is unaffected (`reuseExistingServer` is already `false` there); this purely improves the local-dev experience.
- Independent of the custom-controls feature (PR #211) — separate files, no overlap.