### PR TITLE
fix(e2e): use full Chromium locally after Playwright 1.62 headless-shell default

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,7 +72,15 @@ export default defineConfig({
         // GitHub runner images) instead of downloading a Playwright-managed
         // Chromium, which is blocked by unreliable runner egress for large
         // downloads. Local runs keep the pinned Playwright-managed browser.
-        channel: process.env.CI ? 'chrome' : undefined,
+        //
+        // Locally this must be the full Chromium build, not Playwright's default
+        // `chromium-headless-shell`. The shell does not drive a full render loop, so
+        // MapLibre never finishes loading tiles: sources stay `isSourceLoaded() === false`
+        // and `map.loaded()` never becomes true, which hangs every `waitForMapIdle` until
+        // it times out. This only started biting with Playwright 1.62, which made the
+        // headless shell the default for the `chromium` project. CI is unaffected because
+        // it pins `chrome`, which is why this passed CI while failing locally.
+        channel: process.env.CI ? 'chrome' : 'chromium',
         headless: true,
         launchOptions: {
           args: [


### PR DESCRIPTION
Fixes the local e2e regression introduced by the Playwright 1.62.1 bump in #220.

## Symptom

After #220, `pnpm run test:maplibre` fails ~73 of 234 tests locally (15.7m), all with the same signature:

```
waitForPendingUpdates timeout error, can't wait more than 60000ms for gm_main
TimeoutError: page.waitForFunction: Timeout exceeded  at utils/basic.ts (waitForMapIdle)
```

CI stayed green throughout, so this only hits developers.

## Cause

Playwright 1.62 made `chromium-headless-shell` the default browser for the `chromium` project. The shell does not drive a full render loop, so MapLibre never finishes loading tiles. Instrumenting the stuck state shows geoman's own work completes and it is MapLibre that never settles:

```
gm_main      diff:false  pending:0  isSourceLoaded:false   <-- stuck forever
gm_temporary diff:false  pending:0  isSourceLoaded:true
gm_internal  diff:false  pending:0  isSourceLoaded:true
map.loaded(): false   areTilesLoaded(): false
```

`waitForMapIdle` therefore blocks until `waitForPendingUpdates` hits its own 60s `LOAD_TIMEOUT`.

**Why CI didn't catch it:** the config pins `channel: 'chrome'` on CI (system Chrome on the runner image) and only used the Playwright-managed browser locally, so CI never exercises the bumped browser at all. This also explains a red herring worth recording — running locally with `CI=1` appears to fix the failures, but that is because `CI=1` switches the channel to system Chrome, **not** because of CI's longer timeouts or its 2 retries. Raising the local timeouts to CI's 60s does not help; the run just fails slower.

It is not a WebGL problem either: WebGL2 is available in the shell via SwiftShader (`ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device), SwiftShader driver)`).

## Fix

Pin `channel: 'chromium'` locally, selecting the full Chromium build. CI keeps `chrome` for the documented egress reason.

## Verification

| | before | after |
|---|---|---|
| maplibre (local) | 73 failed, 15.7m | **234 passed, 50.9s** |
| mapbox (local) | — | **234 passed, 54.4s** |

Bisected to confirm attribution: v0.9.0 with Playwright 1.61.0 passes 234/234; v0.9.0 with *only* the Playwright bump applied reproduces the 73 failures. `formatter`, `lint:all`, and `workspace:validate` also pass.

Note `playwright install chromium` provides both builds, so no extra download step is needed.
