### PR TITLE
fix(draw): honor gm_temporary marker icon-image (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Marker draw previews now use registered raster images named by a literal
+  `layerStyles.marker.gm_temporary` `icon-image`, respecting image dimensions,
+  pixel ratio, `icon-size`, `icon-anchor`, and `icon-opacity` on MapLibre and Mapbox
+  ([#122](https://github.com/geoman-io/maplibre-geoman/issues/122)). Register the image
+  before enabling marker draw mode. Missing images and non-literal image expressions
+  retain the default SVG fallback; the built-in marker remains unchanged.
+
 ## [0.9.2] - 2026-09-11
 
 ### Changed

--- a/packages/core/src/core/map/base/index.ts
+++ b/packages/core/src/core/map/base/index.ts
@@ -75,6 +75,10 @@ export abstract class BaseMapAdapter<
 
   abstract removeImage(id: string): void;
 
+  getImageData(_id: string): { imageData: ImageData; pixelRatio: number } | null {
+    return null;
+  }
+
   abstract getBounds(): [LngLatTuple, LngLatTuple];
 
   abstract fitBounds(bounds: [LngLatTuple, LngLatTuple], options?: BaseFitBoundsOptions): void;

--- a/packages/core/src/modes/draw/marker.ts
+++ b/packages/core/src/modes/draw/marker.ts
@@ -1,7 +1,7 @@
 import { SOURCES } from '@/core/features/constants.ts';
 import type { GeoJsonShapeFeature } from '@/types/geojson.ts';
 import type { FeatureSourceName } from '@/types/features.ts';
-import type { LngLatTuple } from '@/types/map/index.ts';
+import type { AnchorPosition, LngLatTuple } from '@/types/map/index.ts';
 import type { DrawModeName, ShapeName } from '@/types/modes/index.ts';
 import { BaseDraw } from '@/modes/draw/base.ts';
 import { isMapPointerEvent } from '@/utils/guards/map.ts';
@@ -92,6 +92,35 @@ export class DrawMarker extends BaseDraw {
         ? (symbolLayer.layout['icon-size'] as number)
         : undefined;
 
+    const iconImage = symbolLayer?.layout?.['icon-image'];
+    const iconAnchor = symbolLayer?.layout?.['icon-anchor'];
+    const anchor = typeof iconAnchor === 'string' ? (iconAnchor as AnchorPosition) : 'bottom';
+    const image =
+      typeof iconImage === 'string' && iconImage !== 'default-marker'
+        ? this.gm.mapAdapter.getImageData(iconImage)
+        : null;
+
+    if (image) {
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+      if (context) {
+        const { imageData, pixelRatio } = image;
+        const scale = (typeof iconSize === 'number' ? iconSize : 1) / pixelRatio;
+        canvas.width = imageData.width;
+        canvas.height = imageData.height;
+        context.putImageData(imageData, 0, 0);
+        canvas.style.width = `${imageData.width * scale}px`;
+        canvas.style.height = `${imageData.height * scale}px`;
+        canvas.style.pointerEvents = 'none';
+        if (typeof iconOpacity === 'number') canvas.style.opacity = String(iconOpacity);
+        const element = document.createElement('div');
+        element.classList.add('marker-wrapper');
+        element.style.lineHeight = '0';
+        element.appendChild(canvas);
+        return this.gm.mapAdapter.createDomMarker({ draggable: false, anchor, element }, [0, 0]);
+      }
+    }
+
     // Calculate pixel size based on icon-size (base size is 36px at icon-size: 0.18)
     const baseSize = 36;
     const defaultIconSize = 0.18;
@@ -109,7 +138,7 @@ export class DrawMarker extends BaseDraw {
     return this.gm.mapAdapter.createDomMarker(
       {
         draggable: false,
-        anchor: 'bottom',
+        anchor,
         element: iconElement,
       },
       [0, 0],

--- a/packages/mapbox/src/adapter/index.ts
+++ b/packages/mapbox/src/adapter/index.ts
@@ -101,6 +101,24 @@ export class MapboxAdapter extends BaseMapAdapter<
     }
   }
 
+  getImageData(id: string) {
+    const style = this.mapInstance.style;
+    if (!style) return null;
+    const imageId = style
+      .listImages()
+      .find((image) => (typeof image === 'string' ? image === id : image.name === id));
+    const image = imageId ? style.getImage(imageId) : null;
+    if (!image?.data) return null;
+    return {
+      imageData: new ImageData(
+        new Uint8ClampedArray(image.data.data),
+        image.data.width,
+        image.data.height,
+      ),
+      pixelRatio: image.pixelRatio,
+    };
+  }
+
   getBounds(): [LngLatTuple, LngLatTuple] {
     const mapBounds = this.mapInstance.getBounds()!;
     return mapBounds.toArray() as [LngLatTuple, LngLatTuple];

--- a/packages/maplibre/src/adapter/index.ts
+++ b/packages/maplibre/src/adapter/index.ts
@@ -89,6 +89,19 @@ export class MaplibreAdapter extends BaseMapAdapter<ml.Map, ml.GeoJSONSource, Ma
     }
   }
 
+  getImageData(id: string) {
+    const image = this.mapInstance.getImage(id);
+    if (!image?.data) return null;
+    return {
+      imageData: new ImageData(
+        new Uint8ClampedArray(image.data.data),
+        image.data.width,
+        image.data.height,
+      ),
+      pixelRatio: image.pixelRatio,
+    };
+  }
+
   getBounds(): [LngLatTuple, LngLatTuple] {
     const mapBounds = this.mapInstance.getBounds();
     return mapBounds.toArray() as [LngLatTuple, LngLatTuple];

--- a/tests/draw/custom-marker-image.spec.ts
+++ b/tests/draw/custom-marker-image.spec.ts
@@ -1,0 +1,114 @@
+import test, { expect } from '@playwright/test';
+import { waitForGeoman, waitForMapIdle } from '@tests/utils/basic.ts';
+
+for (const pixelRatio of [1, 2]) {
+  test(`marker preview uses the temporary custom image at pixel ratio ${pixelRatio}`, async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await waitForGeoman(page);
+    await page.evaluate(async (ratio) => {
+      const map = window.mapInstance;
+      await window.geoman.destroy({ removeSources: true });
+      const data = new Uint8Array(40 * 60 * 4);
+      for (let offset = 0; offset < data.length; offset += 4) {
+        data.set([255, 0, 128, 255], offset);
+      }
+      map.addImage('custom-marker', { width: 40, height: 60, data }, { pixelRatio: ratio });
+      map.addImage('main-marker', {
+        width: 1,
+        height: 1,
+        data: new Uint8Array([0, 0, 255, 255]),
+      });
+      window.geoman = new window.GeomanClass(map, {
+        layerStyles: {
+          marker: {
+            gm_main: [{ type: 'symbol', layout: { 'icon-image': 'main-marker', 'icon-size': 1 } }],
+            gm_temporary: [
+              {
+                type: 'symbol',
+                layout: {
+                  'icon-image': 'custom-marker',
+                  'icon-size': 0.5,
+                  'icon-anchor': 'center',
+                  'icon-allow-overlap': true,
+                },
+                paint: { 'icon-opacity': 0.5 },
+              },
+            ],
+          },
+        },
+      });
+    }, pixelRatio);
+    await waitForGeoman(page);
+    await page.evaluate(() => window.geoman.enableMode('draw', 'marker'));
+    await page.mouse.move(500, 350);
+
+    const preview = await page.evaluate(() => {
+      const element = window.geoman.markerPointer.marker?.getElement();
+      const canvas =
+        element instanceof HTMLCanvasElement ? element : element?.querySelector('canvas');
+      if (!canvas) return null;
+      return {
+        width: canvas.style.width,
+        height: canvas.style.height,
+        opacity: canvas.style.opacity,
+        pixel: Array.from(canvas.getContext('2d')!.getImageData(0, 0, 1, 1).data),
+        centered: element?.className.includes('marker-anchor-center'),
+      };
+    });
+    expect(preview).toEqual({
+      width: `${20 / pixelRatio}px`,
+      height: `${30 / pixelRatio}px`,
+      opacity: '0.5',
+      pixel: [255, 0, 128, 255],
+      centered: true,
+    });
+
+    await page.mouse.click(500, 350);
+    await waitForMapIdle(page);
+    expect(await page.evaluate(() => window.geoman.features.exportGeoJson().features.length)).toBe(
+      1,
+    );
+    await page.evaluate(() => window.geoman.disableMode('draw', 'marker'));
+    expect(await page.evaluate(() => window.geoman.markerPointer.marker)).toBeNull();
+    expect(await page.locator('canvas').count()).toBe(1);
+  });
+}
+
+test('an unavailable custom image falls back and is picked up on the next draw session', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await waitForGeoman(page);
+  await page.evaluate(async () => {
+    const map = window.mapInstance;
+    await window.geoman.destroy({ removeSources: true });
+    window.geoman = new window.GeomanClass(map, {
+      layerStyles: {
+        marker: {
+          gm_temporary: [
+            {
+              type: 'symbol',
+              layout: { 'icon-image': 'late-marker', 'icon-size': 1 },
+            },
+          ],
+        },
+      },
+    });
+  });
+  await waitForGeoman(page);
+  await page.evaluate(() => window.geoman.enableMode('draw', 'marker'));
+  await expect(page.locator('.marker-wrapper svg')).toHaveCount(1);
+  await page.evaluate(async () => {
+    await window.geoman.disableMode('draw', 'marker');
+    window.mapInstance.addImage('late-marker', {
+      width: 1,
+      height: 1,
+      data: new Uint8Array([255, 0, 0, 255]),
+    });
+    await window.geoman.enableMode('draw', 'marker');
+  });
+  await expect(page.locator('.marker-wrapper svg')).toHaveCount(0);
+  await expect(page.locator('.marker-wrapper canvas')).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary
Fixes #122.

Reproduced on current default branch `master` at cb1819efbbf8fd2cf3000534cb8491b31c4e74d4 (Geoman 0.9.2 / MapLibre GL JS 6.7.0). Marker previews always used the default SVG even when `gm_temporary.icon-image` named a registered custom image. Both new image/pixel-ratio browser regressions failed before the fix.

- Read the registered raster image through the map adapter and render it inside the existing DOM marker pointer, preserving snapping and draw-event behavior.
- Honor the temporary image's dimensions, pixel ratio, numeric size/opacity, and literal anchor. Keep the default SVG fallback for missing images and non-literal image expressions.
- Cover temporary versus main image selection, pixel data, 1x/2x images, non-square dimensions, anchor/opacity, click-to-create, cleanup, and image registration between draw sessions.

## Validation
- Full MapLibre Chromium suite: **237 passed, 1 skipped**.
- Unit suite: **110 passed**.
- Focused custom-image and existing default-style tests pass on both MapLibre and Mapbox.
- Both builds (including bundle/type verification), typecheck, lint, formatting, API-surface check, workspace validation, and diff check pass.
- Full Mapbox Chromium suite: **237 passed, 1 skipped**.
- Final custom-image regression file rerun on both engines: **3 passed each**.

## Scope / implementation notes
Register custom raster images before enabling marker drawing. This does not add expression evaluation, SDF colorization, or live animated-image updates to the DOM preview.
MapLibre uses public `Map.getImage`. Mapbox has no public image-read equivalent, so its existing style image access is isolated in the Mapbox adapter; it resolves identifiers returned by `style.listImages()` rather than constructing private image IDs.
